### PR TITLE
Improved dialogs in the preferences

### DIFF
--- a/app/src/main/java/com/zionhuang/music/ui/fragments/SettingsFragment.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/fragments/SettingsFragment.kt
@@ -159,8 +159,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
                         preference.value = newValue
                         preference.callChangeListener(newValue)
 
-                        // dismiss the dialog
-                        dialog.dismiss()
+                        // invoke the on change listener
+                        preference.callChangeListener(preference.value)
                     }
                     .setNegativeButton(android.R.string.cancel, null)
                     .show()
@@ -176,6 +176,9 @@ class SettingsFragment : PreferenceFragmentCompat() {
                     .setPositiveButton(android.R.string.ok) { _, _ ->
                         // save the new value to the preference
                         preference.text = binding.editText.text.toString()
+
+                        // invoke the on change listener
+                        preference.callChangeListener(preference.text)
                     }
                     .setNegativeButton(android.R.string.cancel, null)
                     .show()

--- a/app/src/main/java/com/zionhuang/music/ui/fragments/SettingsFragment.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/fragments/SettingsFragment.kt
@@ -14,10 +14,13 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.preference.*
 import com.google.android.material.color.DynamicColors
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.transition.MaterialFadeThrough
 import com.zionhuang.music.R
 import com.zionhuang.music.constants.Constants.APP_URL
+import com.zionhuang.music.databinding.DialogTextPreferenceBinding
 import com.zionhuang.music.extensions.preferenceLiveData
+import com.zionhuang.music.extensions.sharedPreferences
 import com.zionhuang.music.playback.MediaSessionConnection
 import com.zionhuang.music.update.UpdateInfo.*
 import com.zionhuang.music.viewmodels.UpdateViewModel
@@ -134,5 +137,50 @@ class SettingsFragment : PreferenceFragmentCompat() {
         }
 
         viewModel.checkForUpdate()
+    }
+
+    /**
+     * Show a preference dialog using the [MaterialAlertDialogBuilder]
+     */
+    override fun onDisplayPreferenceDialog(preference: Preference) {
+        when (preference) {
+            // Show a MaterialAlertDialogBuilder when the preference type is ListPreference
+            is ListPreference -> {
+                // get the index of the previous selected item
+                val prefIndex = preference.entryValues.indexOf(preference.value)
+                MaterialAlertDialogBuilder(requireContext())
+                    .setTitle(preference.title)
+                    .setSingleChoiceItems(preference.entries, prefIndex) { dialog, index ->
+
+                        // get the new ListPreference value
+                        val newValue = preference.entryValues[index].toString()
+
+                        // save the new value and call the onPreferenceChange Method
+                        preference.value = newValue
+                        preference.callChangeListener(newValue)
+
+                        // dismiss the dialog
+                        dialog.dismiss()
+                    }
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .show()
+            }
+            is EditTextPreference -> {
+                val binding = DialogTextPreferenceBinding.inflate(layoutInflater)
+                binding.editText.setText(
+                    requireContext().sharedPreferences.getString(preference.key, "")
+                )
+                MaterialAlertDialogBuilder(requireContext())
+                    .setTitle(preference.title)
+                    .setView(binding.root)
+                    .setPositiveButton(android.R.string.ok) { _, _ ->
+                        // save the new value to the preference
+                        preference.text = binding.editText.text.toString()
+                    }
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .show()
+            }
+            else -> super.onDisplayPreferenceDialog(preference)
+        }
     }
 }

--- a/app/src/main/res/layout/dialog_text_preference.xml
+++ b/app/src/main/res/layout/dialog_text_preference.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingTop="10dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/textLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="20dp">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/editText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>


### PR DESCRIPTION
Hey,
first of all thanks for all your work spent onto the project, it's the best looking app for me for listening to music while having a lot of features included (love the proxy) :)

This PR will improve the design of the preference dialogs by using the `MaterialAlertDialogBuilder` when showing preferences instead of using the preference dialogs by the `androidx` library since the `material` library doesn't have its own implementation of the `PreferenceFragmentCompat`.
Affected preference dialogs are the dialog of the `ListPreference` as well as the `EditTextPreference`.
 
Old:
![image](https://user-images.githubusercontent.com/82752168/191241391-a15c258e-12ea-439f-b4bd-3e61aa1e256e.png)

New:
![image](https://user-images.githubusercontent.com/82752168/191241944-e38a6b4c-171e-4ce7-afc8-c0afa972304f.png)

Regards