### PR TITLE
Use BaseSettingsFragment for all preferences fragments

### DIFF
--- a/app/src/main/java/com/zionhuang/music/ui/fragments/settings/BackupRestoreSettingsFragment.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/fragments/settings/BackupRestoreSettingsFragment.kt
@@ -16,6 +16,7 @@ import com.zionhuang.music.db.checkpoint
 import com.zionhuang.music.extensions.zipInputStream
 import com.zionhuang.music.extensions.zipOutputStream
 import com.zionhuang.music.ui.activities.MainActivity
+import com.zionhuang.music.ui.fragments.base.BaseSettingsFragment
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -25,7 +26,7 @@ import java.util.zip.ZipEntry
 import kotlin.system.exitProcess
 
 
-class BackupRestoreSettingsFragment : PreferenceFragmentCompat() {
+class BackupRestoreSettingsFragment : BaseSettingsFragment() {
     private val wantToBackup = mutableListOf(/* Preferences */ true, /* Database */ true)
     private val wantToRestore = mutableListOf(/* Preferences */ true, /* Database */ true)
     private val backupLauncher = registerForActivityResult(ActivityResultContracts.CreateDocument("application/octet-stream")) { uri ->

--- a/app/src/main/java/com/zionhuang/music/ui/fragments/settings/GeneralSettingsFragment.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/fragments/settings/GeneralSettingsFragment.kt
@@ -1,10 +1,10 @@
 package com.zionhuang.music.ui.fragments.settings
 
 import android.os.Bundle
-import androidx.preference.PreferenceFragmentCompat
 import com.zionhuang.music.R
+import com.zionhuang.music.ui.fragments.base.BaseSettingsFragment
 
-class GeneralSettingsFragment : PreferenceFragmentCompat() {
+class GeneralSettingsFragment : BaseSettingsFragment() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.pref_general)
     }

--- a/app/src/main/java/com/zionhuang/music/ui/fragments/settings/PlayerAudioSettingsFragment.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/fragments/settings/PlayerAudioSettingsFragment.kt
@@ -5,11 +5,11 @@ import android.media.audiofx.AudioEffect.*
 import android.os.Bundle
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.preference.Preference
-import androidx.preference.PreferenceFragmentCompat
 import com.zionhuang.music.R
 import com.zionhuang.music.playback.MediaSessionConnection
+import com.zionhuang.music.ui.fragments.base.BaseSettingsFragment
 
-class PlayerAudioSettingsFragment : PreferenceFragmentCompat() {
+class PlayerAudioSettingsFragment : BaseSettingsFragment() {
     private val activityResultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {}
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {


### PR DESCRIPTION
Reason: The `Audio quality` dialog in the `Player and audio` settings doesn't use the proper Material Dialog style (bg color etc)