### PR TITLE
Allow applications to control Media playback

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -146,7 +146,7 @@
         </receiver>
         <receiver
             android:name="androidx.media.session.MediaButtonReceiver"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
                 <action android:name="android.media.AUDIO_BECOMING_NOISY" />


### PR DESCRIPTION
Allowing the receiver to be exported will allow external applications to control playback. Atleast AFAIK no side effects. Fixes gadgetbridge not being able to control playback for this app. 