### PR TITLE
Add color to the collapsed bottom sheet of the queue

### DIFF
--- a/app/src/main/java/com/zionhuang/music/ui/component/BottomSheet.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/component/BottomSheet.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.zionhuang.music.constants.NavigationBarAnimationSpec
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -38,6 +39,7 @@ fun BottomSheet(
     state: BottomSheetState,
     modifier: Modifier = Modifier,
     backgroundColor: Color = MaterialTheme.colorScheme.surface,
+    collapsedColor: Color = backgroundColor,
     onDismiss: (() -> Unit)? = null,
     collapsedContent: @Composable BoxScope.() -> Unit,
     content: @Composable BoxScope.() -> Unit,
@@ -79,10 +81,7 @@ fun BottomSheet(
         if (!state.isCollapsed) {
             BoxWithConstraints(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .graphicsLayer {
-                        alpha = ((state.progress - 0.25f) * 4).coerceIn(0f, 1f)
-                    },
+                    .fillMaxSize(),
                 content = content
             )
         }
@@ -93,15 +92,22 @@ fun BottomSheet(
                     .graphicsLayer {
                         alpha = 1f - (state.progress * 4).coerceAtMost(1f)
                     }
-                    .clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null,
-                        onClick = state::expandSoft
-                    )
-                    .fillMaxWidth()
-                    .height(state.collapsedBound),
-                content = collapsedContent
-            )
+                    .zIndex(1f)
+                    .background(collapsedColor)
+                    .fillMaxSize(),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = state::expandSoft
+                        )
+                        .fillMaxWidth()
+                        .height(state.collapsedBound),
+                    content = collapsedContent
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/zionhuang/music/ui/player/Queue.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/player/Queue.kt
@@ -284,6 +284,7 @@ fun Queue(
     BottomSheet(
         state = state,
         backgroundColor = MaterialTheme.colorScheme.surfaceColorAtElevation(NavigationBarDefaults.Elevation),
+        collapsedColor = MaterialTheme.colorScheme.secondaryContainer,
         modifier = modifier,
         collapsedContent = {
             Row(


### PR DESCRIPTION
This is just a suggestion which would "fix" (if you can call that a bug) #778.

Before:
![Screenshot_20230709_081037_InnerTune Debug](https://github.com/z-huang/InnerTune/assets/115401023/22bca822-c654-4de6-9e58-b1806b5c2002)

After:
![Screenshot_20230709_123236_InnerTune Debug](https://github.com/z-huang/InnerTune/assets/115401023/b2fd85ff-90a1-40aa-89ba-d9a2a93a267c)

So it is more clear that the bottom bar is draggable or tappable. Also it fits more the bottom bar in the extended queue view:

https://github.com/z-huang/InnerTune/assets/115401023/94163015-8e76-4aed-9f28-8793ee55edc4

