### PR TITLE
Move pitch and tempo to a separate dialog box

### DIFF
--- a/app/src/main/res/drawable/discover_tune.xml
+++ b/app/src/main/res/drawable/discover_tune.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M517.5,357.5L517.5,282.5L637.5,282.5L637.5,127.5L712.5,127.5L712.5,282.5L832.5,282.5L832.5,357.5L517.5,357.5ZM637.5,832.5L637.5,442.5L712.5,442.5L712.5,832.5L637.5,832.5ZM247.5,832.5L247.5,677.5L127.5,677.5L127.5,602.5L442.5,602.5L442.5,677.5L322.5,677.5L322.5,832.5L247.5,832.5ZM247.5,517.5L247.5,127.5L322.5,127.5L322.5,517.5L247.5,517.5Z"/>
+</vector>

--- a/app/src/main/res/values-DE/strings.xml
+++ b/app/src/main/res/values-DE/strings.xml
@@ -62,6 +62,7 @@
     <string name="retry">Wiederholen</string>
     <string name="radio">Radio</string>
     <string name="shuffle">Shuffle</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Details</string>
@@ -85,6 +86,7 @@
     <string name="remove_from_history">aus dem Wiedergabeverlauf entfernen</string>
     <string name="search_online">Online-Suche</string>
     <string name="sync">Sync</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Datum hinzugefügt</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -64,6 +64,7 @@
     <string name="retry">Паўтарыць</string>
     <string name="radio">Радыё</string>
     <string name="shuffle">Перамяшаць</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Падрабязнасці</string>
@@ -87,6 +88,7 @@
     <string name="remove_from_history">Выдаліць з гісторыі</string>
     <string name="search_online">Шукаць у сетцы</string>
     <string name="sync">Cінхранізацыя</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Нядаўна дададзена</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -62,6 +62,7 @@
     <string name="retry">পুনরায় চেষ্টা করুন</string>
     <string name="radio">বেতার</string>
     <string name="shuffle">এলোমেলো</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">বিস্তারিত</string>
@@ -85,6 +86,7 @@
     <string name="remove_from_history">ইতিহাস থেকে অপসারণ</string>
     <string name="search_online">অনলাইন এ খুঁজুন</string>
     <string name="sync">সুসংগত</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">সময় সম্পাদনা করা হয়েছে</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -64,6 +64,7 @@
     <string name="retry">Zkusit znovu</string>
     <string name="radio">Rádio</string>
     <string name="shuffle">Náhodně</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Podrobnosti</string>
@@ -87,6 +88,7 @@
     <string name="remove_from_history">Remove from history</string>
     <string name="search_online">Hledat online</string>
     <string name="sync">Sync</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Datum přidání</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -63,6 +63,7 @@
     <string name="retry">Reintentar</string>
     <string name="radio">Radio</string>
     <string name="shuffle">Mezclar</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Detalles</string>
@@ -86,6 +87,7 @@
     <string name="remove_from_history">Eliminar del historial</string>
     <string name="search_online">Buscar online</string>
     <string name="sync">Sincronizar</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Fecha añadida</string>

--- a/app/src/main/res/values-fa-rIR/strings.xml
+++ b/app/src/main/res/values-fa-rIR/strings.xml
@@ -62,6 +62,7 @@
     <string name="retry">تلاش‌مجدد</string>
     <string name="radio">رادیو</string>
     <string name="shuffle">بُرزدن</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Details</string>
@@ -85,6 +86,7 @@
     <string name="remove_from_history">Remove from history</string>
     <string name="search_online">Search online</string>
     <string name="sync">Sync</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">تاریخ اضافه‌شده</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -62,6 +62,7 @@
     <string name="retry">Toisto</string>
     <string name="radio">Radio</string>
     <string name="shuffle">Sekoita</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Details</string>
@@ -85,6 +86,7 @@
     <string name="remove_from_history">Remove from history</string>
     <string name="search_online">Search online</string>
     <string name="sync">Sync</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Lisäyspäivä</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -63,6 +63,7 @@
     <string name="retry">Réessayer</string>
     <string name="radio">Radio</string>
     <string name="shuffle">Lecture aléatoire</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Détails</string>
@@ -86,6 +87,7 @@
     <string name="remove_from_history">Supprimer de l\'historique</string>
     <string name="search_online">Rechercher en ligne</string>
     <string name="sync">Synchroniser</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Date d\'ajout</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -62,6 +62,7 @@
     <string name="retry">Újra</string>
     <string name="radio">Rádió</string>
     <string name="shuffle">Keverés</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Részletek</string>
@@ -85,6 +86,7 @@
     <string name="remove_from_history">Előzményből eltávolít</string>
     <string name="search_online">Keresés online</string>
     <string name="sync">Szinkron.</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Létrehozás dátuma</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -61,6 +61,7 @@
     <string name="retry">Mencoba kembali</string>
     <string name="radio">Radio</string>
     <string name="shuffle">Acak</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Rincian</string>
@@ -84,6 +85,7 @@
     <string name="remove_from_history">Remove from history</string>
     <string name="search_online">Cari secara online</string>
     <string name="sync">Sync</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Tanggal ditambahkan</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -63,6 +63,7 @@
     <string name="retry">Riprova</string>
     <string name="radio">Radio</string>
     <string name="shuffle">Mischia</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Dettagli</string>
@@ -86,6 +87,7 @@
     <string name="remove_from_history">Rimuovi da cronologia</string>
     <string name="search_online">Cerca online</string>
     <string name="sync">Sincronizza</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Data di aggiunta</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -61,6 +61,7 @@
     <string name="retry">再試行</string>
     <string name="radio">ラジオ</string>
     <string name="shuffle">シャッフル</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">詳細</string>
@@ -84,6 +85,7 @@
     <string name="remove_from_history">履歴から削除</string>
     <string name="search_online">オンラインで検索</string>
     <string name="sync">同期</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">追加日時</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -61,6 +61,7 @@
     <string name="retry">다시</string>
     <string name="radio">Radio</string>
     <string name="shuffle">셔플</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Details</string>
@@ -84,6 +85,7 @@
     <string name="remove_from_history">Remove from history</string>
     <string name="search_online">Search online</string>
     <string name="sync">Sync</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">추가된 날짜</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -62,6 +62,7 @@
     <string name="retry">വീണ്ടും ശ്രമിക്കുക</string>
     <string name="radio">റേഡിയോ</string>
     <string name="shuffle">ഷഫിൾ</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Details</string>
@@ -85,6 +86,7 @@
     <string name="remove_from_history">Remove from history</string>
     <string name="search_online">Search online</string>
     <string name="sync">Sync</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">ചേർത്ത തീയതി</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -62,6 +62,7 @@
     <string name="retry">Opnieuw</string>
     <string name="radio">Radio</string>
     <string name="shuffle">Shuffle</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Details</string>
@@ -85,6 +86,7 @@
     <string name="remove_from_history">Verwijder uit geschiedenis</string>
     <string name="search_online">Zoek online</string>
     <string name="sync">Synchroniseer</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Datum toegevoegd</string>

--- a/app/src/main/res/values-or-rIN/strings.xml
+++ b/app/src/main/res/values-or-rIN/strings.xml
@@ -62,6 +62,7 @@
     <string name="retry">ପୁନଃ ଚେଷ୍ଟା କରନ୍ତୁ</string>
     <string name="radio">ରେଡିଓ</string>
     <string name="shuffle">ଶଫଲ୍ କରନ୍ତୁ</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">ବିବରଣୀ</string>
@@ -85,6 +86,7 @@
     <string name="remove_from_history">Remove from history</string>
     <string name="search_online">ଅନଲାଇନ୍ ସନ୍ଧାନ କରନ୍ତୁ</string>
     <string name="sync">Sync</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">ତାରିଖ ରେ ଯୋଡା ଯାଇଛି</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -62,6 +62,7 @@
     <string name="retry">ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ</string>
     <string name="radio">ਰੇਡੀਓ</string>
     <string name="shuffle">ਸ਼ਫਲ ਕਰੋ</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">ਵੇਰਵੇ</string>
@@ -85,6 +86,7 @@
     <string name="remove_from_history">ਅਤੀਤ ਵਿੱਚੋਂ ਹਟਾਓ</string>
     <string name="search_online">ਆਨਲਾਈਨ ਖੋਜ ਕਰੋ</string>
     <string name="sync">ਸਿੰਕਰੋਨਾਈਜ਼ ਕਰੋ</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">ਮਿਤੀ</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -64,6 +64,7 @@
     <string name="retry">Spróbuj ponownie</string>
     <string name="radio">Radio</string>
     <string name="shuffle">Losowo</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Szczegóły</string>
@@ -87,6 +88,7 @@
     <string name="remove_from_history">Usuń z historii</string>
     <string name="search_online">Szukaj online</string>
     <string name="sync">Synchronizuj</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Data dodania</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -63,6 +63,7 @@
     <string name="retry">Tentar novamente</string>
     <string name="radio">Rádio</string>
     <string name="shuffle">Aleatório</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Detalhes</string>
@@ -86,6 +87,7 @@
     <string name="remove_from_history">Remove from history</string>
     <string name="search_online">Search online</string>
     <string name="sync">Sync</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Quando adicionada</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -64,6 +64,7 @@
     <string name="retry">Повторить</string>
     <string name="radio">Радио</string>
     <string name="shuffle">Перемешать</string>
+    <string name="reset">Сбросить</string>
 
     <!-- Menu -->
     <string name="details">Подробнее</string>
@@ -87,6 +88,7 @@
     <string name="remove_from_history">Удалить из истории</string>
     <string name="search_online">Поиск в Интернете</string>
     <string name="sync">Синхронизация</string>
+    <string name="playback_control">Контроль аудио</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Недавно добавленные</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -62,6 +62,7 @@
     <string name="retry">Försök igen</string>
     <string name="radio">Radio</string>
     <string name="shuffle">Blanda</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Details</string>
@@ -85,6 +86,7 @@
     <string name="remove_from_history">Remove from history</string>
     <string name="search_online">Search online</string>
     <string name="sync">Sync</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Datum tillagd</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -62,6 +62,7 @@
     <string name="retry">Yeniden dene</string>
     <string name="radio">Radyo</string>
     <string name="shuffle">Karıştır</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Ayrıntılar</string>
@@ -85,6 +86,7 @@
     <string name="remove_from_history">Geçmişten kaldır</string>
     <string name="search_online">Çevrimiçi arama</string>
     <string name="sync">Eşitle</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Eklendiği tarih</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -64,6 +64,7 @@
     <string name="retry">Повторювати</string>
     <string name="radio">Радіо</string>
     <string name="shuffle">Перемішати</string>
+    <string name="reset">Скинути</string>
 
     <!-- Menu -->
     <string name="details">Детальніше</string>
@@ -87,6 +88,7 @@
     <string name="remove_from_history">Видалити з історії</string>
     <string name="search_online">Пошук в Інтернеті</string>
     <string name="sync">Синхронізація</string>
+    <string name="playback_control">Контроль аудіо</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Нещодавно додані</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -61,6 +61,7 @@
     <string name="retry">Thử lại</string>
     <string name="radio">Đài</string>
     <string name="shuffle">Trộn</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Chi tiết</string>
@@ -84,6 +85,7 @@
     <string name="remove_from_history">Xoá khỏi lịch sử</string>
     <string name="search_online">Tìm kiếm trực tuyến</string>
     <string name="sync">Đồng bộ</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Ngày thêm vào</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -61,6 +61,7 @@
     <string name="retry">重试</string>
     <string name="radio">电台</string>
     <string name="shuffle">随机播放</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">详情</string>
@@ -84,6 +85,7 @@
     <string name="remove_from_history">从记录中移除</string>
     <string name="search_online">在线搜索</string>
     <string name="sync">同步</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">新建时间</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -61,6 +61,7 @@
     <string name="retry">重試</string>
     <string name="radio">電台</string>
     <string name="shuffle">隨機播放</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">詳細資訊</string>
@@ -84,6 +85,7 @@
     <string name="remove_from_history">從記錄中移除</string>
     <string name="search_online">線上搜尋</string>
     <string name="sync">同步</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">新增時間</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,7 @@
     <string name="retry">Retry</string>
     <string name="radio">Radio</string>
     <string name="shuffle">Shuffle</string>
+    <string name="reset">Reset</string>
 
     <!-- Menu -->
     <string name="details">Details</string>
@@ -84,6 +85,7 @@
     <string name="remove_from_history">Remove from history</string>
     <string name="search_online">Search online</string>
     <string name="sync">Sync</string>
+    <string name="playback_control">Playback control</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">Date added</string>


### PR DESCRIPTION
Hs @z-huang! I’m new to Kotlin, so my code might be a bit clumsy. This is my attempt not only to ask for new features and improvements, but also to make my small contribution to InnerTune too. It's also supposed to solve [#874](https://github.com/z-huang/InnerTune/issues/874)

Changelog:
1. A new item `Playback control` has been added to the player menu
2. The **pitch and tempo settings** have been moved to a dialog box that is called up when you press `Playback control`
3. The pitch and tempo values are applied in real-time (the user can immediately hear the changes).
4. When the dialog box is called up, the current values are remembered. They will be applied when you press Cancel or outside the window (the user has adjusted the settings and decided to cancel and return to the previous ones)
5. A `Reset` button has also been added, which resets the values to the default. When you press the `Reset` button and then press `Ok`, `Cancel` or outside the window, the default values will be applied. If the user has changed the default values and pressed `Ok`, the values set by the user will be applied (standard behavior for such situations)
6. A new icon has been added for pitch settings, and the old one is now used for Playback control
7. `LazyColumn` is also used in the code so that if the elements do not fit in the window, they can be scrolled.
8. You can see more details on how everything works in the video (it has sound).

https://github.com/z-huang/InnerTune/assets/81887288/2ecfde67-9b2a-4d21-a9eb-55635c8ea9ae


