### PR TITLE
Scroll the queue list to the currently playing song

### DIFF
--- a/app/src/main/java/com/zionhuang/music/ui/component/Items.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/component/Items.kt
@@ -317,7 +317,7 @@ fun SongListItem(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(
-                        color = if (albumIndex != null) Color.Transparent else Color.Black.copy(alpha = 0.4f),
+                        color = if (albumIndex != null) Color.Transparent else Color.Black.copy(alpha = 0.6f),
                         shape = RoundedCornerShape(ThumbnailCornerRadius)
                     )
             )
@@ -507,7 +507,7 @@ fun AlbumListItem(
             modifier = Modifier
                 .size(ListThumbnailSize)
                 .background(
-                    color = Color.Black.copy(alpha = 0.4f),
+                    color = Color.Black.copy(alpha = 0.6f),
                     shape = RoundedCornerShape(ThumbnailCornerRadius)
                 )
         )
@@ -610,7 +610,7 @@ fun AlbumGridItem(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(
-                        color = Color.Black.copy(alpha = 0.4f),
+                        color = Color.Black.copy(alpha = 0.6f),
                         shape = RoundedCornerShape(ThumbnailCornerRadius)
                     )
             ) {
@@ -645,7 +645,7 @@ fun AlbumGridItem(
                 modifier = Modifier
                     .size(36.dp)
                     .clip(CircleShape)
-                    .background(Color.Black.copy(alpha = 0.4f))
+                    .background(Color.Black.copy(alpha = 0.6f))
                     .clickable {
                         coroutineScope.launch {
                             database
@@ -816,7 +816,7 @@ fun MediaMetadataListItem(
             modifier = Modifier
                 .size(ListThumbnailSize)
                 .background(
-                    color = Color.Black.copy(alpha = 0.4f),
+                    color = Color.Black.copy(alpha = 0.6f),
                     shape = RoundedCornerShape(ThumbnailCornerRadius)
                 )
         )
@@ -933,7 +933,7 @@ fun YouTubeListItem(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(
-                        color = if (albumIndex != null) Color.Transparent else Color.Black.copy(alpha = 0.4f),
+                        color = if (albumIndex != null) Color.Transparent else Color.Black.copy(alpha = 0.6f),
                         shape = thumbnailShape
                     )
             )
@@ -1049,7 +1049,7 @@ fun YouTubeGridItem(
                     modifier = Modifier
                         .fillMaxSize()
                         .background(
-                            color = Color.Black.copy(alpha = 0.4f),
+                            color = Color.Black.copy(alpha = 0.6f),
                             shape = thumbnailShape
                         )
                 ) {
@@ -1084,7 +1084,7 @@ fun YouTubeGridItem(
                     modifier = Modifier
                         .size(36.dp)
                         .clip(CircleShape)
-                        .background(Color.Black.copy(alpha = 0.4f))
+                        .background(Color.Black.copy(alpha = 0.6f))
                         .clickable {
                             coroutineScope?.launch(Dispatchers.IO) {
                                 var songs = database

--- a/app/src/main/java/com/zionhuang/music/ui/menu/PlayerMenu.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/menu/PlayerMenu.kt
@@ -72,6 +72,7 @@ fun PlayerMenu(
     mediaMetadata: MediaMetadata?,
     navController: NavController,
     playerBottomSheetState: BottomSheetState,
+    isQueueTrigger: Boolean? = false,
     onShowDetailsDialog: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -150,26 +151,27 @@ fun PlayerMenu(
             onDismiss = { showPitchTempoDialog = false }
         )
     }
+    if (isQueueTrigger != true) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(24.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(top = 24.dp, bottom = 6.dp)
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.volume_up),
+                contentDescription = null,
+                modifier = Modifier.size(28.dp)
+            )
 
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(24.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 24.dp)
-            .padding(top = 24.dp, bottom = 6.dp)
-    ) {
-        Icon(
-            painter = painterResource(R.drawable.volume_up),
-            contentDescription = null,
-            modifier = Modifier.size(28.dp)
-        )
-
-        BigSeekBar(
-            progressProvider = playerVolume::value,
-            onProgressChange = { playerConnection.service.playerVolume.value = it },
-            modifier = Modifier.weight(1f)
-        )
+            BigSeekBar(
+                progressProvider = playerVolume::value,
+                onProgressChange = { playerConnection.service.playerVolume.value = it },
+                modifier = Modifier.weight(1f)
+            )
+        }
     }
 
     GridMenu(
@@ -253,32 +255,37 @@ fun PlayerMenu(
             context.startActivity(Intent.createChooser(intent, null))
             onDismiss()
         }
-        GridMenuItem(
-            icon = R.drawable.info,
-            title = R.string.details
-        ) {
-            onShowDetailsDialog()
-            onDismiss()
-        }
-        GridMenuItem(
-            icon = R.drawable.equalizer,
-            title = R.string.equalizer
-        ) {
-            val intent = Intent(AudioEffect.ACTION_DISPLAY_AUDIO_EFFECT_CONTROL_PANEL).apply {
-                putExtra(AudioEffect.EXTRA_AUDIO_SESSION, playerConnection.player.audioSessionId)
-                putExtra(AudioEffect.EXTRA_PACKAGE_NAME, context.packageName)
-                putExtra(AudioEffect.EXTRA_CONTENT_TYPE, AudioEffect.CONTENT_TYPE_MUSIC)
+        if (isQueueTrigger != true) {
+            GridMenuItem(
+                icon = R.drawable.info,
+                title = R.string.details
+            ) {
+                onShowDetailsDialog()
+                onDismiss()
             }
-            if (intent.resolveActivity(context.packageManager) != null) {
-                activityResultLauncher.launch(intent)
+            GridMenuItem(
+                icon = R.drawable.equalizer,
+                title = R.string.equalizer
+            ) {
+                val intent = Intent(AudioEffect.ACTION_DISPLAY_AUDIO_EFFECT_CONTROL_PANEL).apply {
+                    putExtra(
+                        AudioEffect.EXTRA_AUDIO_SESSION,
+                        playerConnection.player.audioSessionId
+                    )
+                    putExtra(AudioEffect.EXTRA_PACKAGE_NAME, context.packageName)
+                    putExtra(AudioEffect.EXTRA_CONTENT_TYPE, AudioEffect.CONTENT_TYPE_MUSIC)
+                }
+                if (intent.resolveActivity(context.packageManager) != null) {
+                    activityResultLauncher.launch(intent)
+                }
+                onDismiss()
             }
-            onDismiss()
-        }
-        GridMenuItem(
-            icon = R.drawable.tune,
-            title = R.string.advanced
-        ) {
-            showPitchTempoDialog = true
+            GridMenuItem(
+                icon = R.drawable.tune,
+                title = R.string.advanced
+            ) {
+                showPitchTempoDialog = true
+            }
         }
     }
 }

--- a/app/src/main/java/com/zionhuang/music/ui/player/Queue.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/player/Queue.kt
@@ -368,6 +368,7 @@ fun Queue(
             mutableQueueWindows.apply {
                 clear()
                 addAll(queueWindows)
+                reorderableState.listState.scrollToItem(currentWindowIndex)
             }
         }
 

--- a/app/src/main/java/com/zionhuang/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.SwipeToDismiss
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberDismissState
@@ -91,6 +92,7 @@ import com.zionhuang.music.models.toMediaMetadata
 import com.zionhuang.music.playback.ExoDownloadService
 import com.zionhuang.music.playback.queues.ListQueue
 import com.zionhuang.music.ui.component.AutoResizeText
+import com.zionhuang.music.ui.component.DefaultDialog
 import com.zionhuang.music.ui.component.EmptyPlaceholder
 import com.zionhuang.music.ui.component.FontSizeRange
 import com.zionhuang.music.ui.component.LocalMenuState
@@ -181,6 +183,46 @@ fun LocalPlaylistScreen(
                 }
             )
         }
+    }
+
+    var showRemoveDownloadDialog by remember {
+        mutableStateOf(false)
+    }
+
+    if (showRemoveDownloadDialog) {
+        DefaultDialog(
+            onDismiss = { showRemoveDownloadDialog = false },
+            content = {
+                Text(
+                    text = stringResource(R.string.remove_download_playlist_confirm),
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(horizontal = 18.dp)
+                )
+            },
+            buttons = {
+                TextButton(
+                    onClick = { showRemoveDownloadDialog = false }
+                ) {
+                    Text(text = stringResource(android.R.string.cancel))
+                }
+
+                TextButton(
+                    onClick = {
+                        showRemoveDownloadDialog = false
+                        songs.forEach { song ->
+                            DownloadService.sendRemoveDownload(
+                                context,
+                                ExoDownloadService::class.java,
+                                song.song.id,
+                                false
+                            )
+                        }
+                    }
+                ) {
+                    Text(text = stringResource(android.R.string.ok))
+                }
+            }
+        )
     }
 
     val headerItems = 2
@@ -331,14 +373,7 @@ fun LocalPlaylistScreen(
                                             Download.STATE_COMPLETED -> {
                                                 IconButton(
                                                     onClick = {
-                                                        songs.forEach { song ->
-                                                            DownloadService.sendRemoveDownload(
-                                                                context,
-                                                                ExoDownloadService::class.java,
-                                                                song.song.id,
-                                                                false
-                                                            )
-                                                        }
+                                                        showRemoveDownloadDialog = true
                                                     }
                                                 ) {
                                                     Icon(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
     <string name="liked_songs">Liked songs</string>
     <string name="downloaded_songs">Downloaded songs</string>
     <string name="playlist_is_empty">The playlist is empty</string>
+    <string name="remove_download_playlist_confirm">Are you sure you want to remove the downloaded songs from this playlist?</string>
 
     <!-- Button -->
     <string name="retry">Retry</string>


### PR DESCRIPTION
This PR fixes the queue list display to show the currently playing song at the top of the list, which is very useful for large queues. I've also added a way to bring up the bottom menu when you long press on a queue item.

Short spotlight:
https://github.com/z-huang/InnerTune/assets/110673332/a99a4981-ce0e-417c-ae58-e00da24bac61


https://github.com/z-huang/InnerTune/issues/1067
https://github.com/z-huang/InnerTune/issues/1074