### PR TITLE
Append playlist contents to the queue

### DIFF
--- a/app/src/main/java/com/zionhuang/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -392,6 +392,19 @@ fun LocalPlaylistScreen(
                                                 }
                                             }
                                         }
+
+                                        IconButton(
+                                            onClick = {
+                                                playerConnection.addToQueue(
+                                                    items = songs.map { it.song.toMediaItem() }
+                                                )
+                                            }
+                                        ) {
+                                            Icon(
+                                                painter = painterResource(R.drawable.queue_music),
+                                                contentDescription = null
+                                            )
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
This feature allows users to easily add songs from a playlist to the end of the queue. It is especially useful when you want to quickly enqueue songs from specific playlists.


https://github.com/z-huang/InnerTune/assets/110673332/f615d40a-3dbd-4a3e-afda-4c3945e85bd2


Partially related to https://github.com/z-huang/InnerTune/issues/1066