### PR TITLE
Translation update for UA, BE, RU

### DIFF
--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -187,7 +187,7 @@
     <string name="sleep_timer">Таймер рэжыму сну</string>
     <string name="end_of_song">Канец песні</string>
     <plurals name="minute">
-        <item quantity="one" tools:ignore="ImpliedQuantity">1 хвіліна</item>
+        <item quantity="one">%d хвіліна</item>
         <item quantity="few">%d хвіліны</item>
         <item quantity="many">%d хвілін</item>
         <item quantity="other">%d хвілін</item>
@@ -200,11 +200,11 @@
     <!-- Player action -->
     <string name="action_like">Упадабаць</string>
     <string name="action_remove_like">Выдаліць з упадабаных</string>
-    <string name="action_shuffle_on">Shuffle on</string>
-    <string name="action_shuffle_off">Shuffle off</string>
-    <string name="repeat_mode_off">Repeat mode off</string>
-    <string name="repeat_mode_one">Repeat current song</string>
-    <string name="repeat_mode_all">Repeat queue</string>
+    <string name="action_shuffle_on">Уключыць перамешванне</string>
+    <string name="action_shuffle_off">Выключыць перамешванне</string>
+    <string name="repeat_mode_off">Рэжым паўтору выключаны</string>
+    <string name="repeat_mode_one">Паўтарыць бягучую песню</string>
+    <string name="repeat_mode_all">Паўтарыць чаргу</string>
 
     <!-- Queue Title -->
     <string name="queue_all_songs">Усе песні</string>
@@ -282,7 +282,7 @@
     <string name="about">Аб праграме</string>
     <string name="app_version">Версія праграмы</string>
 
-    <string name="new_version_available">New version available</string>
-    <string name="translation_models">Translation Models</string>
-    <string name="clear_translation_models">Clear translation models</string>
+    <string name="new_version_available">Даступная новая версія</string>
+    <string name="translation_models">Мадэлі перакладу</string>
+    <string name="clear_translation_models">Ачысціць мадэлі перакладу</string>
 </resources>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -187,7 +187,7 @@
     <string name="sleep_timer">Таймер сна</string>
     <string name="end_of_song">Конец песни</string>
     <plurals name="minute">
-        <item quantity="one" tools:ignore="ImpliedQuantity">1 минута</item>
+        <item quantity="one">%d минута</item>
         <item quantity="few">%d минуты</item>
         <item quantity="many">%d минут</item>
         <item quantity="other">%d минут</item>
@@ -200,11 +200,11 @@
     <!-- Player action -->
     <string name="action_like">Поставить «Нравится»</string>
     <string name="action_remove_like">Убрать «Нравится»</string>
-    <string name="action_shuffle_on">Shuffle on</string>
-    <string name="action_shuffle_off">Shuffle off</string>
-    <string name="repeat_mode_off">Repeat mode off</string>
-    <string name="repeat_mode_one">Repeat current song</string>
-    <string name="repeat_mode_all">Repeat queue</string>
+    <string name="action_shuffle_on">Включить перемешивание</string>
+    <string name="action_shuffle_off">Выключить перемешивание</string>
+    <string name="repeat_mode_off">Выключить повторение</string>
+    <string name="repeat_mode_one">Повторить текущую песню</string>
+    <string name="repeat_mode_all">Повторить очередь</string>
 
     <!-- Queue Title -->
     <string name="queue_all_songs">Все композиции</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -187,7 +187,7 @@
     <string name="sleep_timer">Таймер сну</string>
     <string name="end_of_song">Кінець пісні</string>
     <plurals name="minute">
-        <item quantity="one" tools:ignore="ImpliedQuantity">1 хвилина</item>
+        <item quantity="one">%d хвилина</item>
         <item quantity="few">%d хвилини</item>
         <item quantity="many">%d хвилин</item>
         <item quantity="other">%d хвилин</item>
@@ -200,11 +200,11 @@
     <!-- Player action -->
     <string name="action_like">Поставити «Подобається»</string>
     <string name="action_remove_like">Прибрати «Подобається»</string>
-    <string name="action_shuffle_on">Shuffle on</string>
-    <string name="action_shuffle_off">Shuffle off</string>
-    <string name="repeat_mode_off">Repeat mode off</string>
-    <string name="repeat_mode_one">Repeat current song</string>
-    <string name="repeat_mode_all">Repeat queue</string>
+    <string name="action_shuffle_on">Увімкнути перемішування</string>
+    <string name="action_shuffle_off">Вимкнути перемішування</string>
+    <string name="repeat_mode_off">Вимкнути повторення</string>
+    <string name="repeat_mode_one">Повторити поточну пісню</string>
+    <string name="repeat_mode_all">Повторити чергу</string>
 
     <!-- Queue Title -->
     <string name="queue_all_songs">Всі композиції</string>


### PR DESCRIPTION
### What's new:

- Translation update for UA, BE, RU
- Removed `tools:ignore="ImpliedQuantity"` from minute plurals in UA, BE, RU translations, because it led to incorrect display of 21, 31, etc. values. For example - 20 хвилин, 1 хвилина, 22 хвилини instead of 20 хвилин, 21 хвилина, 22 хвилини.