### PR TITLE
Update Japanese

### DIFF
--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -1,16 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Bottom navigation -->
     <string name="home">ホーム</string>
     <string name="songs">曲</string>
     <string name="artists">アーティスト</string>
     <string name="albums">アルバム</string>
-    <string name="playlists">プレイリスト</string>
-
+    <string name="playlists">再生リスト</string>
     <!-- Top bar -->
     <plurals name="n_selected">
-        <item quantity="other">%dを選択済み</item>
+        <item quantity="other">%d 個を選択済み</item>
     </plurals>
-
     <!-- Home -->
     <string name="history">履歴</string>
     <string name="stats">統計</string>
@@ -19,50 +18,45 @@
     <string name="quick_picks">おすすめ</string>
     <string name="quick_picks_empty">何曲か再生するとおすすめを生成します</string>
     <string name="new_release_albums">新作アルバム</string>
-
     <!-- History -->
     <string name="today">今日</string>
     <string name="yesterday">昨日</string>
     <string name="this_week">今週</string>
     <string name="last_week">先週</string>
-
     <!-- Stats -->
     <string name="most_played_songs">最も再生された曲</string>
     <string name="most_played_artists">最も再生されたアーティスト</string>
     <string name="most_played_albums">最も再生されたアルバム</string>
-
     <!-- Search -->
     <string name="search">検索</string>
-    <string name="search_yt_music">YouTube Musicを検索…</string>
+    <string name="search_yt_music">YouTube Music を検索…</string>
     <string name="search_library">ライブラリを検索…</string>
-    <string name="filter_library">Library</string>
-    <string name="filter_liked">Liked</string>
-    <string name="filter_downloaded">Downloaded</string>
+    <string name="filter_library">ライブラリ</string>
+    <string name="filter_liked">高評価済み</string>
+    <string name="filter_downloaded">ダウンロード済み</string>
     <string name="filter_all">すべて</string>
     <string name="filter_songs">曲</string>
     <string name="filter_videos">動画</string>
     <string name="filter_albums">アルバム</string>
     <string name="filter_artists">アーティスト</string>
-    <string name="filter_playlists">プレイリスト</string>
-    <string name="filter_community_playlists">コミュニティのプレイリスト</string>
-    <string name="filter_featured_playlists">おすすめのプレイリスト</string>
-    <string name="filter_bookmarked">Bookmarked</string>
+    <string name="filter_playlists">再生リスト</string>
+    <string name="filter_community_playlists">コミュニティの再生リスト</string>
+    <string name="filter_featured_playlists">おすすめの再生リスト</string>
+    <string name="filter_bookmarked">ブックマーク済み</string>
     <string name="no_results_found">見つかりませんでした</string>
-
     <!-- Artist screen -->
     <string name="from_your_library">ライブラリから</string>
-
     <!-- Playlist -->
-    <string name="liked_songs">いいねした曲</string>
+    <string name="liked_songs">高評価した曲</string>
     <string name="downloaded_songs">ダウンロードした曲</string>
-    <string name="playlist_is_empty">プレイリストが空です</string>
-
+    <string name="playlist_is_empty">再生リストが空です</string>
+    <string name="remove_download_playlist_confirm">｢%s｣の再生リスト上の全曲をダウンロード済みから削除しますか？</string>
+    <string name="delete_playlist_confirm">｢%s｣の再生リストを削除してもよろしいですか？</string>
     <!-- Button -->
     <string name="retry">再試行</string>
     <string name="radio">ラジオ</string>
     <string name="shuffle">シャッフル</string>
-    <string name="reset">Reset</string>
-
+    <string name="reset">リセット</string>
     <!-- Menu -->
     <string name="details">詳細</string>
     <string name="edit">編集</string>
@@ -74,19 +68,19 @@
     <string name="remove_from_library">ライブラリから削除</string>
     <string name="download">ダウンロード</string>
     <string name="downloading">ダウンロード中</string>
-    <string name="remove_download">ダウンロード削除</string>
-    <string name="import_playlist">プレイリストをインポート</string>
-    <string name="add_to_playlist">プレイリストに追加</string>
-    <string name="view_artist">アーティスト表示</string>
+    <string name="remove_download">ダウンロードを削除</string>
+    <string name="import_playlist">再生リストをインポート</string>
+    <string name="add_to_playlist">再生リストに追加</string>
+    <string name="view_artist">アーティストを表示</string>
     <string name="view_album">アルバムを表示</string>
     <string name="refetch">再取得</string>
     <string name="share">共有</string>
     <string name="delete">削除</string>
     <string name="remove_from_history">履歴から削除</string>
+    <string name="remove_from_playlist">再生リストから削除</string>
     <string name="search_online">オンラインで検索</string>
     <string name="sync">同期</string>
-    <string name="advanced">Advanced</string>
-
+    <string name="advanced">高度</string>
     <!-- Sort menu -->
     <string name="sort_by_create_date">追加日時</string>
     <string name="sort_by_name">曲名</string>
@@ -96,68 +90,65 @@
     <string name="sort_by_length">長さ</string>
     <string name="sort_by_play_time">再生時間</string>
     <string name="sort_by_custom">カスタム</string>
-
     <!-- Dialog -->
-    <string name="media_id">メディアID</string>
-    <string name="mime_type">MIMEタイプ</string>
+    <string name="media_id">メディア ID</string>
+    <string name="mime_type">MIME タイプ</string>
     <string name="codecs">コーデック</string>
     <string name="bitrate">ビットレート</string>
-    <string name="sample_rate">サンプリングレート</string>
+    <string name="sample_rate">サンプルレート</string>
     <string name="loudness">ラウドネス</string>
     <string name="volume">音量</string>
     <string name="file_size">ファイルサイズ</string>
     <string name="unknown">不明</string>
     <string name="copied">クリップボードにコピー</string>
-
     <string name="edit_lyrics">歌詞を編集</string>
     <string name="search_lyrics">歌詞を検索</string>
-
     <string name="edit_song">曲を編集</string>
     <string name="song_title">曲名</string>
     <string name="song_artists">曲のアーティスト</string>
-    <string name="error_song_title_empty">曲名は空にできません。</string>
-    <string name="error_song_artist_empty">曲のアーティストは空にできません。</string>
+    <string name="error_song_title_empty">曲名は空白にできません。</string>
+    <string name="error_song_artist_empty">曲のアーティストは空白にできません。</string>
     <string name="save">保存</string>
-
-    <string name="choose_playlist">プレイリストを選択</string>
-    <string name="edit_playlist">プレイリストを編集</string>
-    <string name="create_playlist">プレイリストを作成</string>
-    <string name="playlist_name">プレイリスト名</string>
-    <string name="error_playlist_name_empty">プレイリスト名は空白にできません。</string>
-
+    <string name="choose_playlist">再生リストを選択</string>
+    <string name="edit_playlist">再生リストを編集</string>
+    <string name="create_playlist">再生リストを作成</string>
+    <string name="playlist_name">再生リストの名前</string>
+    <string name="error_playlist_name_empty">再生リストの名前は空白にできません。</string>
     <string name="edit_artist">アーティストを編集</string>
     <string name="artist_name">アーティスト名</string>
     <string name="error_artist_name_empty">アーティスト名は空白にできません。</string>
-
+    <string name="duplicates">重複</string>
+    <string name="skip_duplicates">重複をスキップ</string>
+    <string name="add_anyway">気にせず追加</string>
+    <string name="duplicates_description_single">曲はすでに再生リストにあります</string>
+    <string name="duplicates_description_multiple">%d の曲はすでに再生リストにあります</string>
     <!-- Noun -->
     <plurals name="n_song">
-        <item quantity="other">%d曲</item>
+        <item quantity="other">%d 曲</item>
     </plurals>
     <plurals name="n_artist">
-        <item quantity="other">%d アーティスト</item>
+        <item quantity="other">%d 件のアーティスト</item>
     </plurals>
     <plurals name="n_album">
-        <item quantity="other">%d アルバム</item>
+        <item quantity="other">%d 個のアルバム</item>
     </plurals>
     <plurals name="n_playlist">
-        <item quantity="other">%d プレイリスト</item>
+        <item quantity="other">%d 件の再生リスト</item>
     </plurals>
     <plurals name="n_week">
-        <item quantity="other">%d週間</item>
+        <item quantity="other">%d 週間</item>
     </plurals>
     <plurals name="n_month">
-        <item quantity="other">%dか月</item>
+        <item quantity="other">%d ヶ月</item>
     </plurals>
     <plurals name="n_year">
-        <item quantity="other">%d年</item>
+        <item quantity="other">%d 年</item>
     </plurals>
-
     <!-- Snackbar -->
-    <string name="playlist_imported">プレイリストをインポートしました</string>
-    <string name="removed_song_from_playlist">プレイリストから「%s」を削除しました</string>
-    <string name="playlist_synced">プレイリストが同期されました</string>
+    <string name="playlist_imported">再生リストをインポートしました</string>
+    <string name="removed_song_from_playlist">再生リストから「%s」を削除しました</string>
+    <string name="playlist_synced">再生リストが同期されました</string>
     <string name="undo">元に戻す</string>
-
     <!-- Player -->
     <string name="lyrics_not_found">歌詞が見つかりません</string>
     <string name="sleep_timer">スリープタイマー</string>
@@ -169,39 +160,34 @@
     <string name="error_no_internet">ネットワーク接続がありません</string>
     <string name="error_timeout">タイムアウトしました</string>
     <string name="error_unknown">不明なエラー</string>
-
     <!-- Player action -->
-    <string name="action_like">いいね</string>
-    <string name="action_remove_like">いいねを削除</string>
-    <string name="action_shuffle_on">Shuffle on</string>
-    <string name="action_shuffle_off">Shuffle off</string>
-    <string name="repeat_mode_off">Repeat mode off</string>
-    <string name="repeat_mode_one">Repeat current song</string>
-    <string name="repeat_mode_all">Repeat queue</string>
-
+    <string name="action_like">高評価</string>
+    <string name="action_remove_like">高評価を削除</string>
+    <string name="action_shuffle_on">シャッフル ON</string>
+    <string name="action_shuffle_off">シャッフル OFF</string>
+    <string name="repeat_mode_off">リピートモード OFF</string>
+    <string name="repeat_mode_one">現在の曲をリピート</string>
+    <string name="repeat_mode_all">キューをリポート</string>
     <!-- Queue Title -->
     <string name="queue_all_songs">すべての曲</string>
     <string name="queue_searched_songs">検索した曲</string>
-
     <!-- Notification name -->
-    <string name="music_player">音楽プレイヤー</string>
-
+    <string name="music_player">音楽プレーヤー</string>
     <!-- Settings -->
     <string name="settings">設定</string>
     <string name="appearance">外観</string>
-    <string name="enable_dynamic_theme">動的なテーマを有効化</string>
+    <string name="enable_dynamic_theme">ダイナミックテーマを有効化</string>
     <string name="dark_theme">ダークテーマ</string>
-    <string name="dark_theme_on">オン</string>
-    <string name="dark_theme_off">オフ</string>
+    <string name="dark_theme_on">ON</string>
+    <string name="dark_theme_off">OFF</string>
     <string name="dark_theme_follow_system">システムに従う</string>
-    <string name="pure_black">Pure black</string>
+    <string name="pure_black">ピュアブラック</string>
     <string name="default_open_tab">起動時に開くタブ</string>
     <string name="customize_navigation_tabs">ナビゲーションタブのカスタマイズ</string>
     <string name="lyrics_text_position">歌詞テキストの位置</string>
     <string name="left">左</string>
     <string name="center">中央</string>
     <string name="right">右</string>
-
     <string name="content">コンテンツ</string>
     <string name="login">ログイン</string>
     <string name="content_language">コンテンツの既定の言語</string>
@@ -209,10 +195,9 @@
     <string name="system_default">システムに従う</string>
     <string name="enable_proxy">プロキシを有効化</string>
     <string name="proxy_type">プロキシのタイプ</string>
-    <string name="proxy_url">プロキシのURL</string>
-    <string name="restart_to_take_effect">再起動して反映</string>
-
-    <string name="player_and_audio">プレイヤーと音声</string>
+    <string name="proxy_url">プロキシの URL</string>
+    <string name="restart_to_take_effect">再起動をして適用</string>
+    <string name="player_and_audio">プレーヤーと音声</string>
     <string name="audio_quality">音声品質</string>
     <string name="audio_quality_auto">自動</string>
     <string name="audio_quality_high">高</string>
@@ -221,41 +206,37 @@
     <string name="skip_silence">無音部分をスキップ</string>
     <string name="audio_normalization">音声の正規化</string>
     <string name="equalizer">イコライザー</string>
-
     <string name="storage">ストレージ</string>
     <string name="cache">キャッシュ</string>
     <string name="image_cache">画像のキャッシュ</string>
     <string name="song_cache">曲のキャッシュ</string>
     <string name="max_cache_size">最大キャッシュサイズ</string>
     <string name="unlimited">無制限</string>
-    <string name="clear_all_downloads">すべてのダウンロードを削除</string>
+    <string name="clear_all_downloads">すべてのダウンロードを消去</string>
     <string name="max_image_cache_size">画像の最大キャッシュサイズ</string>
-    <string name="clear_image_cache">画像のキャッシュを削除</string>
+    <string name="clear_image_cache">画像のキャッシュを消去</string>
     <string name="max_song_cache_size">曲の最大キャッシュサイズ</string>
-    <string name="clear_song_cache">曲のキャッシュを削除</string>
+    <string name="clear_song_cache">曲のキャッシュを消去</string>
     <string name="size_used">%s 使用中</string>
-
     <string name="privacy">プライバシー</string>
     <string name="pause_listen_history">再生履歴を一時停止</string>
-    <string name="clear_listen_history">再生履歴を削除</string>
-    <string name="clear_listen_history_confirm">すべての再生履歴を削除しますか？</string>
+    <string name="clear_listen_history">再生履歴を消去</string>
+    <string name="clear_listen_history_confirm">すべての再生履歴を消去しますか？</string>
     <string name="pause_search_history">検索履歴の記録を一時停止</string>
-    <string name="clear_search_history">検索履歴を削除</string>
-    <string name="clear_search_history_confirm">すべての検索履歴を削除しますか？</string>
-    <string name="enable_kugou">酷狗 (Kugou) からの歌詞取得を有効化</string>
-
+    <string name="clear_search_history">検索履歴を消去</string>
+    <string name="clear_search_history_confirm">すべての検索履歴を消去しますか？</string>
+    <string name="enable_lrclib">LrcLib での歌詞の取得を有効化</string>
+    <string name="enable_kugou">KuGou での歌詞の取得を有効化</string>
     <string name="backup_restore">バックアップと復元</string>
     <string name="backup">バックアップ</string>
     <string name="restore">復元</string>
-    <string name="imported_playlist">インポートしたプレイリスト</string>
+    <string name="imported_playlist">インポートした再生リスト</string>
     <string name="backup_create_success">バックアップの作成に成功しました</string>
     <string name="backup_create_failed">バックアップを作成できませんでした</string>
     <string name="restore_failed">バックアップの復元に失敗しました</string>
-
     <string name="about">アプリについて</string>
     <string name="app_version">アプリのバージョン</string>
-
-    <string name="new_version_available">New version available</string>
-    <string name="translation_models">Translation Models</string>
-    <string name="clear_translation_models">Clear translation models</string>
+    <string name="new_version_available">新しいバージョンがあります</string>
+    <string name="translation_models">翻訳モデル</string>
+    <string name="clear_translation_models">翻訳モデルを消去</string>
 </resources>


### PR DESCRIPTION
Fix & Update

![Screenshot_2024-08-11-22-31-28-626_com zionhuang music-edit](https://github.com/user-attachments/assets/c92694ec-a79e-448e-a624-32d5a2d7457e)

In Japanese environment, there is a problem that the bottom bar text broken.
I'll ask for a Fix or Hide text label.
`アーティスト`  `アーティ...`
`プレイリスト`  `プレイリ...`