### PR TITLE
Animations for player elements

### DIFF
--- a/app/src/main/java/com/zionhuang/music/ui/player/MiniPlayer.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/player/MiniPlayer.kt
@@ -134,7 +134,7 @@ fun MiniMediaInfo(
             AnimatedContent(
                 targetState = mediaMetadata.thumbnailUrl,
                 transitionSpec = { fadeIn() togetherWith fadeOut() },
-                label = ""
+                label = "CoverBox"
             ) { thumbnailUrl ->
                 AsyncImage(
                     model = thumbnailUrl,
@@ -176,7 +176,7 @@ fun MiniMediaInfo(
             AnimatedContent(
                 targetState = mediaMetadata.title,
                 transitionSpec = { fadeIn() togetherWith fadeOut() },
-                label = ""
+                label = "TitleRow"
             ) { title ->
                 Text(
                     text = title,
@@ -189,14 +189,20 @@ fun MiniMediaInfo(
                 )
             }
 
-            Text(
-                text = mediaMetadata.artists.joinToString { it.name },
-                color = MaterialTheme.colorScheme.secondary,
-                fontSize = 12.sp,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.basicMarquee()
-            )
+            AnimatedContent(
+                targetState = mediaMetadata.artists.joinToString { it.name },
+                transitionSpec = { fadeIn() togetherWith fadeOut() },
+                label = "ArtistsRow"
+            ) { artists ->
+                Text(
+                    text = artists,
+                    color = MaterialTheme.colorScheme.secondary,
+                    fontSize = 12.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.basicMarquee()
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/zionhuang/music/ui/player/MiniPlayer.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/player/MiniPlayer.kt
@@ -1,7 +1,9 @@
 package com.zionhuang.music.ui.player
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
@@ -129,13 +131,19 @@ fun MiniMediaInfo(
         modifier = modifier
     ) {
         Box(modifier = Modifier.padding(6.dp)) {
-            AsyncImage(
-                model = mediaMetadata.thumbnailUrl,
-                contentDescription = null,
-                modifier = Modifier
-                    .size(48.dp)
-                    .clip(RoundedCornerShape(ThumbnailCornerRadius))
-            )
+            AnimatedContent(
+                targetState = mediaMetadata.thumbnailUrl,
+                transitionSpec = { fadeIn() togetherWith fadeOut() },
+                label = ""
+            ) { thumbnailUrl ->
+                AsyncImage(
+                    model = thumbnailUrl,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(RoundedCornerShape(ThumbnailCornerRadius))
+                )
+            }
             androidx.compose.animation.AnimatedVisibility(
                 visible = error != null,
                 enter = fadeIn(),
@@ -165,15 +173,22 @@ fun MiniMediaInfo(
                 .weight(1f)
                 .padding(horizontal = 6.dp)
         ) {
-            Text(
-                text = mediaMetadata.title,
-                color = MaterialTheme.colorScheme.onSurface,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.Bold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.basicMarquee()
-            )
+            AnimatedContent(
+                targetState = mediaMetadata.title,
+                transitionSpec = { fadeIn() togetherWith fadeOut() },
+                label = ""
+            ) { title ->
+                Text(
+                    text = title,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.basicMarquee()
+                )
+            }
+
             Text(
                 text = mediaMetadata.artists.joinToString { it.name },
                 color = MaterialTheme.colorScheme.secondary,

--- a/app/src/main/java/com/zionhuang/music/ui/player/Player.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/player/Player.kt
@@ -126,17 +126,18 @@ fun BottomSheetPlayer(
     }
     var sliderPosition by remember { mutableStateOf<Long?>(null) }
     var targetPosition by remember { mutableFloatStateOf(position.toFloat()) }
+    var isDragging by remember { mutableStateOf(false) }
 
 
     val animatedTime by animateFloatAsState(
         targetValue = (sliderPosition ?: position).toFloat(),
-        animationSpec = tween(durationMillis = 100, easing = LinearEasing), label = ""
+        animationSpec = tween(durationMillis = if (isDragging) 0 else 100, easing = LinearEasing), label = ""
     )
 
     LaunchedEffect(playbackState) {
         if (playbackState == STATE_READY) {
             while (isActive) {
-                delay(500)
+                delay(100)
                 position = playerConnection.player.currentPosition
                 duration = playerConnection.player.duration
             }
@@ -244,10 +245,12 @@ fun BottomSheetPlayer(
                 value = sliderPosition?.toFloat() ?: position.toFloat(),
                 valueRange = 0f..(if (duration == C.TIME_UNSET) 0f else duration.toFloat()),
                 onValueChange = {
+                    isDragging = true
                     targetPosition = it
                     sliderPosition = it.toLong()
                 },
                 onValueChangeFinished = {
+                    isDragging = false
                     sliderPosition?.let {
                         playerConnection.player.seekTo(it)
                         targetPosition = it.toFloat()

--- a/app/src/main/java/com/zionhuang/music/ui/player/Player.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/player/Player.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastForEachIndexed
 import androidx.media3.common.C
 import androidx.media3.common.Player.REPEAT_MODE_ALL
 import androidx.media3.common.Player.REPEAT_MODE_OFF
@@ -198,7 +199,7 @@ fun BottomSheetPlayer(
                             .fillMaxWidth()
                             .padding(horizontal = PlayerHorizontalPadding)
                     ) {
-                        artistNames.forEachIndexed { index, artistName ->
+                        artistNames.fastForEachIndexed { index, artistName ->
                             val artist = if (index < artists.size) artists[index] else null
                             Text(
                                 text = artistName,

--- a/app/src/main/java/com/zionhuang/music/ui/player/Player.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/player/Player.kt
@@ -188,7 +188,7 @@ fun BottomSheetPlayer(
                             navController.navigate("album/${mediaMetadata.album!!.id}")
                             state.collapseSoft()
                         }
-                        .heightIn(max = 25.dp)
+                        .heightIn(min = 27.dp, max = 27.dp)
                 )
             }
 
@@ -220,7 +220,7 @@ fun BottomSheetPlayer(
                                         state.collapseSoft()
                                     }
                                 }
-                                    .heightIn(max = 20.dp)
+                                    .heightIn(min = 20.dp, max = 20.dp)
                             )
 
                             if (index != artistNames.lastIndex) {


### PR DESCRIPTION
Changes:
- Smooth transitions for song cover, title, and artist labels in the miniplayer
- Limited line height for title/artist labels in player to prevent horizontal UI movement (found with Chinese fonts, fixes vertical animation bug)
- Smooth transitions for title and artist labels in the player
- Elapsed time label animation on manual seek
- fixed rare crash caused by empty artist list


https://github.com/user-attachments/assets/8dde21c3-b566-4e12-b0ba-50c6c565aac7


@z-huang you might want to lower the slider refresh delay value as I was working on this pull request before your recent changes.