### PR TITLE
Filter duplicates in history

### DIFF
--- a/app/src/main/java/com/zionhuang/music/viewmodels/HistoryViewModel.kt
+++ b/app/src/main/java/com/zionhuang/music/viewmodels/HistoryViewModel.kt
@@ -22,7 +22,7 @@ class HistoryViewModel @Inject constructor(
 
     val events = database.events()
         .map { events ->
-            events.groupBy {
+            events.distinctBy { it.song }.groupBy {
                 val date = it.event.timestamp.toLocalDate()
                 val daysAgo = ChronoUnit.DAYS.between(date, today).toInt()
                 when {


### PR DESCRIPTION
Issue link - https://github.com/z-huang/InnerTune/issues/1369
Only the latest song-event is present in history (as in YouTube Music).
Before 
![Screenshot_20240821_164749](https://github.com/user-attachments/assets/29bb1838-938c-4f45-a685-7c18aa22c86a)
After
![Screenshot_20240821_164859](https://github.com/user-attachments/assets/df732f52-13e7-46db-8965-6999e35e4a81)
