### PR TITLE
Fix crash onDestroy when rotating

### DIFF
--- a/app/src/main/java/com/zionhuang/music/MainActivity.kt
+++ b/app/src/main/java/com/zionhuang/music/MainActivity.kt
@@ -189,7 +189,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        if (dataStore.get(StopMusicOnTaskClearKey, false) && playerConnection?.isPlaying?.value == true) {
+        if (dataStore.get(StopMusicOnTaskClearKey, false) && playerConnection?.isPlaying?.value == true && isFinishing) {
             stopService(Intent(this, MusicService::class.java))
             unbindService(serviceConnection)
             playerConnection = null


### PR DESCRIPTION
When merging [your commit](ec326ef8df3ccb1e6f2dfafdf2a3e31fdcc6aed8) into my fork I came across a bug, when rotating the screen `onDestroy()` is called. We need to make sure the app is being killed if doing so. [Here](https://developer.android.com/reference/android/app/Activity.html#onDestroy()) is the doc about it that says about using `isFinishing`.