### PR TITLE
Limit consecutive "auto skip player error" skips 

### DIFF
--- a/app/src/main/java/com/zionhuang/music/ui/player/Queue.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/player/Queue.kt
@@ -404,6 +404,7 @@ fun Queue(
                                                     playerConnection.player.togglePlayPause()
                                                 } else {
                                                     playerConnection.player.seekToDefaultPosition(window.firstPeriodIndex)
+                                                    playerConnection.player.prepare()
                                                     playerConnection.player.playWhenReady = true
                                                 }
                                             }


### PR DESCRIPTION
When encountering a queue of broken songs (ex. internet disconnects), it keeps rapidly skipping (and you can't pause it) until the queue ends or finds a cached songs. With this change, after a certain amount of songs have been automatically skipped, require user intervention to start playback again.

I'm open to adding some ui prompt or notification when it stop skipping (OuterTune just sends a toast), and/or other changes, let me know