### PR TITLE
Remove outdated Discord translations

### DIFF
--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -260,7 +260,7 @@
     <string name="enable_lrclib">Activer le fournisseur de paroles LrcLib</string>
     <string name="hide_explicit">Masquer le contenu explicite</string>
     <string name="discord_integration">Intégration Discord</string>
-    <string name="discord_information">Vous pouvez vous connecter en toute sécurité. InnerTune ne fera qu’extraire votre jeton et tout le reste sera stocké localement.</string>
+
     <string name="dismiss">Abandonner</string>
     <string name="options">Options</string>
     <string name="preview">Prévisualisation</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -239,7 +239,7 @@
     <string name="remove_download_playlist_confirm">Bạn có thực sự muốn xóa tất cả \"%s\" bài hát trong danh sách phát khỏi bộ nhớ Bài hát được tải xuống không?</string>
     <string name="delete_playlist_confirm">Bạn có thực sự muốn xóa \"%s\" danh sách phát không?</string>
     <string name="not_logged_in">Chưa đăng nhập</string>
-    <string name="discord_information">Bạn có thể đăng nhập một cách an toàn. InnerTune sẽ chỉ trích xuất mã thông báo của bạn và mọi thứ khác sẽ được lưu trữ cục bộ.</string>
+
     <string name="enable_lrclib">Bật nhà cung cấp lời bài hát LrcLib</string>
     <string name="discord_integration">Tích hợp Discord</string>
     <string name="dismiss">Bỏ qua</string>


### PR DESCRIPTION
A string was changed and some translations still included the older text, this should mark them as non-translated again.

Does not include PT-BR as that is to be fixed with #1549 