### PR TITLE
Widgets support (uncompleted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ A Material 3 YouTube Music client for Android
 [![Latest release](https://img.shields.io/github/v/release/z-huang/InnerTune?include_prereleases)](https://github.com/z-huang/music/releases)
 [![License](https://img.shields.io/github/license/z-huang/InnerTune)](https://www.gnu.org/licenses/gpl-3.0)
 [![Downloads](https://img.shields.io/github/downloads/z-huang/InnerTune/total)](https://github.com/z-huang/InnerTune/releases)
+[![Translation](https://hosted.weblate.org/widget/innertune/svg-badge.svg)](https://hosted.weblate.org/engage/innertune/)
 
 [<img src="https://github.com/machiav3lli/oandbackupx/blob/034b226cea5c1b30eb4f6a6f313e4dadcbb0ece4/badge_github.png" alt="Get it on GitHub" height="80">](https://github.com/z-huang/InnerTune/releases/latest)
 [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" height="80">](https://f-droid.org/packages/com.zionhuang.music)
 [<img src="https://gitlab.com/IzzyOnDroid/repo/-/raw/master/assets/IzzyOnDroid.png" height="80">](https://apt.izzysoft.de/fdroid/index/apk/com.zionhuang.music)
+
 
 [Compare versions](https://github.com/z-huang/InnerTune/wiki/App-Versions)
 
@@ -62,11 +64,13 @@ recommend [Pano Scrobbler](https://play.google.com/store/apps/details?id=com.arn
 2. In the three dots menu at the top-right of the screen, click "Developer settings"
 3. Enable "Unknown sources"
 
-## Contributing Translations
+## Translating
 
-Follow the [instructions](https://developer.android.com/guide/topics/resources/localization) and
-create a pull request. If possible, please build the app beforehand and make sure there is no error
-before you create a pull request.
+If you'd like to help translate InnerTune, check out [our project in Weblate.](https://hosted.weblate.org/engage/innertune/) Weblate allows us to solve issues with translation inconsistency, edited strings, etc.
+
+> Preferably do not send pull requests if you can. They can cause merging issues, which can lead to the loss of translation work from you or other people.
+
+Thank you for helping translate InnerTune!
 
 ## Donate
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,6 +106,8 @@ ksp {
 }
 
 dependencies {
+    implementation(libs.glance)
+
     implementation(libs.guava)
     implementation(libs.coroutines.guava)
     implementation(libs.concurrent.futures)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -161,6 +161,16 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/turntable_info" />
         </receiver>
+        <receiver android:name=".NowPlayingWidgetReceiver"
+            android:label="@string/now_playing_widget_title"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/now_playing_info" />
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -150,6 +150,17 @@
         <meta-data
             android:name="com.google.android.gms.car.application"
             android:resource="@xml/automotive_app_desc" />
+
+        <receiver android:name=".TurntableWidgetReceiver"
+            android:label="@string/turntable_widget_title"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/turntable_info" />
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/zionhuang/music/Widgets.kt
+++ b/app/src/main/java/com/zionhuang/music/Widgets.kt
@@ -1,0 +1,57 @@
+package com.zionhuang.music
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.glance.Button
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.action.actionStartActivity
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.provideContent
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.padding
+import androidx.glance.text.Text
+
+class TurntableWidget : GlanceAppWidget() {
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+
+        // In this method, load data needed to render the AppWidget.
+        // Use `withContext` to switch to another thread for long running
+        // operations.
+
+        provideContent {
+            // create your AppWidget here
+            TurntableContent()
+        }
+    }
+
+    @Composable
+    private fun TurntableContent() {
+//        Column(
+//            modifier = GlanceModifier.fillMaxSize(),
+//            verticalAlignment = Alignment.Top,
+//            horizontalAlignment = Alignment.CenterHorizontally
+//        ) {
+//            Text(text = "Where to?", modifier = GlanceModifier.padding(12.dp))
+//            Row(horizontalAlignment = Alignment.CenterHorizontally) {
+//                Button(
+//                    text = "Home",
+//                    onClick = actionStartActivity<MainActivity>()
+//                )
+//                Button(
+//                    text = "Work",
+//                    onClick = actionStartActivity<MainActivity>()
+//                )
+//            }
+//        }
+    }
+}
+
+class TurntableWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = TurntableWidget()
+}

--- a/app/src/main/java/com/zionhuang/music/Widgets.kt
+++ b/app/src/main/java/com/zionhuang/music/Widgets.kt
@@ -1,23 +1,81 @@
 package com.zionhuang.music
 
-import android.content.Context
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.unit.dp
-import androidx.glance.Button
 import androidx.glance.GlanceId
+import androidx.glance.LocalContext
+import androidx.glance.appwidget.provideContent
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import android.graphics.BitmapFactory
+import android.graphics.drawable.BitmapDrawable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.glance.Image
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.session.GlanceSessionManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.drawable.toBitmap
+import androidx.core.graphics.drawable.toBitmapOrNull
+import androidx.glance.Button
 import androidx.glance.GlanceModifier
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.LocalContext
+import androidx.glance.LocalSize
 import androidx.glance.action.actionStartActivity
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.CircularProgressIndicator
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
-import androidx.glance.appwidget.provideContent
+import androidx.glance.appwidget.SizeMode
+import androidx.glance.appwidget.cornerRadius
 import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
 import androidx.glance.layout.Column
+import androidx.glance.layout.ContentScale
 import androidx.glance.layout.Row
-import androidx.glance.layout.fillMaxSize
-import androidx.glance.layout.padding
-import androidx.glance.text.Text
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.absolutePadding
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.size
+import androidx.glance.layout.wrapContentSize
+import coil.ImageLoader
+import coil.compose.rememberAsyncImagePainter
+import coil.compose.rememberImagePainter
+import coil.imageLoader
+import coil.request.ErrorResult
+import coil.request.SuccessResult
+import coil.transform.CircleCropTransformation
+import com.zionhuang.music.playback.PlayerConnection
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import kotlin.math.roundToInt
 
 class TurntableWidget : GlanceAppWidget() {
+
+    val sessionManager = GlanceSessionManager
+
+    override val sizeMode: SizeMode = SizeMode.Exact
+
     override suspend fun provideGlance(context: Context, id: GlanceId) {
 
         // In this method, load data needed to render the AppWidget.
@@ -30,28 +88,123 @@ class TurntableWidget : GlanceAppWidget() {
         }
     }
 
+    private suspend fun Context.fetchImage(url: String): Bitmap? {
+        val request = ImageRequest.Builder(this).data(url).build()
+        return when (val result = imageLoader.execute(request)) {
+            is ErrorResult -> throw result.throwable
+            is SuccessResult -> result.drawable.toBitmapOrNull()
+        }
+    }
+    private var playerConnection by mutableStateOf<PlayerConnection?>(null)
+
     @Composable
     private fun TurntableContent() {
-//        Column(
-//            modifier = GlanceModifier.fillMaxSize(),
-//            verticalAlignment = Alignment.Top,
-//            horizontalAlignment = Alignment.CenterHorizontally
-//        ) {
-//            Text(text = "Where to?", modifier = GlanceModifier.padding(12.dp))
-//            Row(horizontalAlignment = Alignment.CenterHorizontally) {
-//                Button(
-//                    text = "Home",
-//                    onClick = actionStartActivity<MainActivity>()
-//                )
-//                Button(
-//                    text = "Work",
-//                    onClick = actionStartActivity<MainActivity>()
-//                )
-//            }
-//        }
+        val context = LocalContext.current
+        val thumbnailUrl = "https://picsum.photos/200/300"
+        var thumbnail by remember(thumbnailUrl) { mutableStateOf<Bitmap?>(null) }
+
+        LaunchedEffect(thumbnailUrl) {
+            thumbnail = context.fetchImage(thumbnailUrl)
+        }
+        Box(
+            modifier = GlanceModifier.fillMaxSize()
+        ) {
+            if (thumbnail != null) {
+                Image(
+                    provider = ImageProvider(thumbnail!!),
+                    contentDescription = "Thumbnail",
+                    contentScale = ContentScale.Crop,
+                    modifier = GlanceModifier.fillMaxSize().cornerRadius(256.dp)
+                )
+
+            } else {
+                CircularProgressIndicator()
+            }
+
+            Column(
+                modifier = GlanceModifier.fillMaxSize()
+            ) {
+                Row(
+                    modifier = GlanceModifier.fillMaxWidth().defaultWeight(),
+                ) {
+                    Spacer(modifier = GlanceModifier.defaultWeight())
+                    Button(
+                        text = "TopRight",
+                        onClick = actionStartActivity<MainActivity>(),
+                        modifier = GlanceModifier.wrapContentSize()
+                    )
+                }
+                Spacer(modifier = GlanceModifier.defaultWeight())
+                Spacer(modifier = GlanceModifier.defaultWeight()) // This spacer pushes the bottom row to the bottom
+                Row(
+                    modifier = GlanceModifier.fillMaxWidth()
+                ) {
+                    Button(
+                        text = "BottomLeft",
+                        onClick = actionStartActivity<MainActivity>(),
+                        modifier = GlanceModifier.wrapContentSize()
+                    )
+                    Spacer(modifier = GlanceModifier.defaultWeight())
+                }
+            }
+        }
     }
 }
 
 class TurntableWidgetReceiver : GlanceAppWidgetReceiver() {
     override val glanceAppWidget: GlanceAppWidget = TurntableWidget()
+}
+
+class NowPlayingWidget : GlanceAppWidget() {
+
+    val sessionManager = GlanceSessionManager
+
+    override val sizeMode: SizeMode = SizeMode.Exact
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+
+        // In this method, load data needed to render the AppWidget.
+        // Use `withContext` to switch to another thread for long running
+        // operations.
+
+        provideContent {
+            // create your AppWidget here
+            NowPlayingContent()
+        }
+    }
+
+    private suspend fun Context.fetchImage(url: String): Bitmap? {
+        val request = ImageRequest.Builder(this).data(url).build()
+        return when (val result = imageLoader.execute(request)) {
+            is ErrorResult -> throw result.throwable
+            is SuccessResult -> result.drawable.toBitmapOrNull()
+        }
+    }
+    private var playerConnection by mutableStateOf<PlayerConnection?>(null)
+
+    @Composable
+    private fun NowPlayingContent() {
+        val context = LocalContext.current
+        val thumbnailUrl = "https://picsum.photos/200/300"
+        var thumbnail by remember(thumbnailUrl) { mutableStateOf<Bitmap?>(null) }
+
+        LaunchedEffect(thumbnailUrl) {
+            thumbnail = context.fetchImage(thumbnailUrl)
+        }
+        if (thumbnail != null) {
+            Image(
+                provider = ImageProvider(thumbnail!!),
+                contentDescription = "Thumbnail",
+                contentScale = ContentScale.Crop,
+                modifier = GlanceModifier.fillMaxSize()
+            )
+
+        } else {
+            CircularProgressIndicator()
+        }
+    }
+}
+
+class NowPlayingWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = NowPlayingWidget()
 }

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -260,7 +260,7 @@
     <string name="enable_lrclib">Activer le fournisseur de paroles LrcLib</string>
     <string name="hide_explicit">Masquer le contenu explicite</string>
     <string name="discord_integration">Intégration Discord</string>
-    <string name="discord_information">Vous pouvez vous connecter en toute sécurité. InnerTune ne fera qu’extraire votre jeton et tout le reste sera stocké localement.</string>
+
     <string name="dismiss">Abandonner</string>
     <string name="options">Options</string>
     <string name="preview">Prévisualisation</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -18,7 +18,7 @@
     <string name="mood_and_genres">Humor e Gêneros</string>
     <string name="account">Conta</string>
     <string name="quick_picks">Escolhas rápidas</string>
-    <string name="quick_picks_empty">Escute mais para gerar suas escolhas rápidas</string>
+    <string name="quick_picks_empty">Escute à mais música para gerar suas escolhas rápidas</string>
     <string name="new_release_albums">Novos álbuns lançados</string>
     <!-- History -->
     <string name="today">Hoje</string>
@@ -229,9 +229,9 @@
     <string name="clear_song_cache">Limpar a cache de músicas</string>
     <string name="size_used">%s usados</string>
     <string name="privacy">Privacidade</string>
-    <string name="pause_listen_history">Pausar o histórico</string>
-    <string name="clear_listen_history">Limpar o histórico</string>
-    <string name="clear_listen_history_confirm">Você tem certeza que deseja limpar todo o histórico?</string>
+    <string name="pause_listen_history">Pausar o histórico de escuta</string>
+    <string name="clear_listen_history">Limpar o histórico de escuta</string>
+    <string name="clear_listen_history_confirm">Você tem certeza que deseja limpar todo o histórico de escuta?</string>
     <string name="pause_search_history">Pausar histórico de pesquisa</string>
     <string name="clear_search_history">Limpar histórico de pesquisa</string>
     <string name="clear_search_history_confirm">Tem certeza que deseja limpar todo o seu histórico de pesquisa?</string>
@@ -265,11 +265,45 @@
     <string name="logout">Sair</string>
     <string name="enable_discord_rpc">Ativar Rich Presence</string>
     <string name="not_logged_in">Não logado</string>
-    <string name="discord_information">Você pode fazer login com segurança. O InnerTune extrairá somente o seu token, e todo o resto é armazenado localmente.</string>
+    <string name="discord_information">O InnerTune usa a biblioteca KizzyRPC para definir o status da sua conta do Discord. Isto envolve o uso da conexão Discord Gateway, que pode ser considerado uma violação dos termos de serviço do Discord. Porém, não há nenhum caso conhecido de contas de usuários sendo suspensas por esta razão. Use por sua conta e risco.
+\n
+\nO InnerTune extrairá somente o seu token, e todo o resto é armazenado localmente.</string>
     <string name="sided">Ao lado</string>
     <string name="hide_explicit">Esconder conteúdo explícito</string>
     <string name="player_text_alignment">Alinhamento do texto do reprodutor</string>
     <string name="player_slider_style">Estilo do slider do reprodutor</string>
     <string name="default_">Padrão</string>
     <string name="squiggly">Cobrinha</string>
+    <string name="your_youtube_playlists">Suas playlists do YouTube</string>
+    <string name="action_like_all">Curtir tudo</string>
+    <string name="action_remove_like_all">Remover todos os likes</string>
+    <string name="grid_cell_size">Tamanho da célula da grade</string>
+    <string name="auto_load_more_desc">Adicionar mais músicas automaticamente quando o fim da fila é atingido, se possível</string>
+    <string name="listen_history">Histórico de escuta</string>
+    <string name="disable_screenshot">Desativar capturas de tela</string>
+    <string name="similar_to">Parecido com</string>
+    <string name="library_song_empty">Músicas da biblioteca aparecerão aqui</string>
+    <string name="library_artist_empty">Artistas da biblioteca aparecerão aqui</string>
+    <string name="library_album_empty">Álbuns da biblioteca aparecerão aqui</string>
+    <string name="other_versions">Outras versões</string>
+    <string name="keep_listening">Continue ouvindo</string>
+    <string name="add_all_to_library">Adicionar tudo à biblioteca</string>
+    <string name="remove_from_queue">Remover da fila</string>
+    <string name="tempo_and_pitch">Tempo e Tom</string>
+    <string name="player">Reprodutor</string>
+    <string name="misc">Outros</string>
+    <string name="small">Pequeno</string>
+    <string name="big">Grande</string>
+    <string name="queue">Fila</string>
+    <string name="persistent_queue_desc">Restaurar sua última fila ao iniciar o app</string>
+    <string name="auto_load_more">Tocar mais músicas automaticamente</string>
+    <string name="auto_skip_next_on_error">Pular automaticamente para a próxima música quando um erro ocorre</string>
+    <string name="auto_skip_next_on_error_desc">Garanta uma experiência de reprodução contínua</string>
+    <string name="stop_music_on_task_clear">Parar música ao remover dos apps recentes</string>
+    <string name="search_history">Histórico de pesquisa</string>
+    <string name="disable_screenshot_desc">Quando esta opção está ativada, as capturas de tela e a visualização do app nos recentes são desativadas.</string>
+    <string name="forgotten_favorites">Favoritos esquecidos</string>
+    <string name="library_playlist_empty">Suas playlists aparecerão aqui</string>
+    <string name="theme">Tema</string>
+    <string name="remove_all_from_library">Remover tudo da biblioteca</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -239,7 +239,7 @@
     <string name="remove_download_playlist_confirm">Bạn có thực sự muốn xóa tất cả \"%s\" bài hát trong danh sách phát khỏi bộ nhớ Bài hát được tải xuống không?</string>
     <string name="delete_playlist_confirm">Bạn có thực sự muốn xóa \"%s\" danh sách phát không?</string>
     <string name="not_logged_in">Chưa đăng nhập</string>
-    <string name="discord_information">Bạn có thể đăng nhập một cách an toàn. InnerTune sẽ chỉ trích xuất mã thông báo của bạn và mọi thứ khác sẽ được lưu trữ cục bộ.</string>
+
     <string name="enable_lrclib">Bật nhà cung cấp lời bài hát LrcLib</string>
     <string name="discord_integration">Tích hợp Discord</string>
     <string name="dismiss">Bỏ qua</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -11,10 +11,10 @@
         <item quantity="other">已选择 %d 个项目</item>
     </plurals>
     <!-- Home -->
-    <string name="history">历史记录</string>
+    <string name="history">历史</string>
     <string name="stats">统计</string>
     <string name="mood_and_genres">情绪和流派</string>
-    <string name="account">Account</string>
+    <string name="account">账号</string>
     <string name="quick_picks">歌曲快选</string>
     <string name="quick_picks_empty">听一些歌曲来生成歌曲快选</string>
     <string name="new_release_albums">新专辑</string>
@@ -31,7 +31,7 @@
     <string name="search">搜索</string>
     <string name="search_yt_music">搜索 YouTube Music…</string>
     <string name="search_library">搜索媒体库…</string>
-    <string name="filter_library">库</string>
+    <string name="filter_library">媒体库</string>
     <string name="filter_liked">喜欢</string>
     <string name="filter_downloaded">已下载</string>
     <string name="filter_all">全部</string>
@@ -54,7 +54,7 @@
     <string name="retry">重试</string>
     <string name="radio">电台</string>
     <string name="shuffle">随机播放</string>
-    <string name="reset">Reset</string>
+    <string name="reset">重置</string>
     <!-- Menu -->
     <string name="details">详情</string>
     <string name="edit">编辑</string>
@@ -74,7 +74,7 @@
     <string name="refetch">刷新</string>
     <string name="share">分享</string>
     <string name="delete">移除</string>
-    <string name="remove_from_history">从记录中移除</string>
+    <string name="remove_from_history">从历史中移除</string>
     <string name="search_online">在线搜索</string>
     <string name="sync">同步</string>
     <string name="advanced">高级</string>
@@ -211,12 +211,12 @@
     <string name="clear_song_cache">清除歌曲缓存</string>
     <string name="size_used">已使用 %s</string>
     <string name="privacy">隐私</string>
-    <string name="pause_listen_history">暂停听歌记录</string>
+    <string name="pause_listen_history">暂停听歌历史</string>
     <string name="clear_listen_history">清除听歌历史</string>
-    <string name="clear_listen_history_confirm">你确定要清除所有听歌记录吗？</string>
-    <string name="pause_search_history">暂停搜索记录</string>
-    <string name="clear_search_history">清除搜索记录</string>
-    <string name="clear_search_history_confirm">您确定要清除所有搜索记录吗？</string>
+    <string name="clear_listen_history_confirm">是否确定要清除所有听歌历史？</string>
+    <string name="pause_search_history">暂停搜索历史</string>
+    <string name="clear_search_history">清除搜索历史</string>
+    <string name="clear_search_history_confirm">是否确定要清除所有搜索历史？</string>
     <string name="enable_kugou">使用酷狗音乐提供歌词</string>
     <string name="backup_restore">备份与还原</string>
     <string name="backup">备份</string>
@@ -232,4 +232,48 @@
     <string name="clear_translation_models">清除翻译模型</string>
     <string name="delete_playlist_confirm">是否确实要删除播放列表“%s”？</string>
     <string name="remove_download_playlist_confirm">您真的想从下载的歌曲存储中删除所有“%s”播放列表中的歌曲吗？</string>
+    <string name="your_youtube_playlists">您的 YouTube 播放列表</string>
+    <string name="other_versions">其他版本</string>
+    <string name="library_artist_empty">媒体库音乐人将显示在此处</string>
+    <string name="library_album_empty">媒体库专辑将显示在此处</string>
+    <string name="library_playlist_empty">您的播放列表将显示在此处</string>
+    <string name="add_anyway">仍要添加</string>
+    <string name="duplicates_description_multiple">%d 首歌曲已在您的播放列表中</string>
+    <string name="action_remove_like_all">移除全部喜欢</string>
+    <string name="theme">主题</string>
+    <string name="player">播放器</string>
+    <string name="player_text_alignment">播放器文本对齐</string>
+    <string name="default_">默认</string>
+    <string name="misc">杂项</string>
+    <string name="grid_cell_size">网格大小</string>
+    <string name="small">小</string>
+    <string name="big">大</string>
+    <string name="not_logged_in">未登录</string>
+    <string name="queue">排队</string>
+    <string name="hide_explicit">隐藏不适宜内容</string>
+    <string name="enable_lrclib">使用 LrcLib 提供歌词</string>
+    <string name="options">选项</string>
+    <string name="preview">预览</string>
+    <string name="login_failed">登录失败</string>
+    <string name="logout">登出</string>
+    <string name="discord_integration">Discord 集成</string>
+    <string name="enable_discord_rpc">启用 Rich Presence</string>
+    <string name="action_like_all">喜欢全部</string>
+    <string name="library_song_empty">媒体库歌曲将显示在此处</string>
+    <string name="duplicates_description_single">这首歌曲已在您的播放列表中</string>
+    <string name="dismiss">关闭</string>
+    <string name="player_slider_style">播放器滑块样式</string>
+    <string name="keep_listening">继续听</string>
+    <string name="add_all_to_library">全部添加到媒体库</string>
+    <string name="remove_all_from_library">全部从媒体库中移除</string>
+    <string name="remove_from_playlist">从播放列表中移除</string>
+    <string name="tempo_and_pitch">节奏和音调</string>
+    <string name="duplicates">重复项</string>
+    <string name="skip_duplicates">跳过重复项</string>
+    <string name="sided">靠边</string>
+    <string name="squiggly">波浪</string>
+    <string name="listen_history">听歌历史</string>
+    <string name="search_history">搜索历史</string>
+    <string name="disable_screenshot">禁用截屏</string>
+    <string name="disable_screenshot_desc">启用此选项后， 您无法截屏，也无法在“最近用过”中看到此应用的内容。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -331,4 +331,7 @@
 
     <string name="turntable_widget_title">Turntable</string>
     <string name="turntable_widget_description">Quick access to your most recently played track.</string>
+
+    <string name="now_playing_widget_title">Now Playing</string>
+    <string name="now_playing_widget_description">Quick access to your media controls.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -328,4 +328,7 @@
     <string name="new_version_available">New version available</string>
     <string name="translation_models">Translation Models</string>
     <string name="clear_translation_models">Clear translation models</string>
+
+    <string name="turntable_widget_title">Turntable</string>
+    <string name="turntable_widget_description">Quick access to your most recently played track.</string>
 </resources>

--- a/app/src/main/res/xml/now_playing_info.xml
+++ b/app/src/main/res/xml/now_playing_info.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="240dp"
+    android:minHeight="60dp"
+    android:updatePeriodMillis="86400000"
+    android:description="@string/now_playing_widget_description"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen">
+</appwidget-provider>

--- a/app/src/main/res/xml/turntable_info.xml
+++ b/app/src/main/res/xml/turntable_info.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="160dp"
+    android:minHeight="128dp"
+    android:updatePeriodMillis="86400000"
+    android:description="@string/turntable_widget_description"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen">
+</appwidget-provider>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidGradlePlugin = "8.5.1"
+androidGradlePlugin = "8.5.1" # TODO 8.6.0
 annotation = "1.8.2"
 json = "20240303"
 kotlin = "2.0.10"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidGradlePlugin = "8.6.0"
+androidGradlePlugin = "8.5.1"
 annotation = "1.8.2"
 json = "20240303"
 kotlin = "2.0.10"
@@ -88,6 +88,8 @@ firebase-perf-plugin = { module = "com.google.firebase:perf-plugin", version = "
 
 mlkit-language-id = { group = "com.google.mlkit", name = "language-id", version = "17.0.6" }
 mlkit-translate = { group = "com.google.mlkit", name = "translate", version = "17.0.3" }
+
+glance = { group = "androidx.glance", name = "glance-appwidget", version = "1.1.0"}
 
 [plugins]
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
I have initialized two widgets named like the ones on YT Music. Right now, it can't do any actions, i have just initialized them and made it display a random image fetched from the internet as a placeholder template to fetch the thumbnail image later on. 

But, I have run into quite a bit of issues. I have created the widget using Glance, a Jetpack Compose like widget system. But, the components are not backwards compatible, so I cannot use a Jetpack image with a Glance widget. And, since Glance is fairly new, many APIs have not been fully created yet, such as aspect ratio, crop shape, alignment, etc... I have needed them countless times, but they just don't exist. 

Because of this, should I switch to using xml layout to build the widget? This can avoid many complications with the widget in the future. 