### PR TITLE
Fix artist items continuation

### DIFF
--- a/app/src/main/java/com/zionhuang/music/ui/screens/artist/ArtistItemsScreen.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/screens/artist/ArtistItemsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Checkbox
@@ -56,6 +57,7 @@ import com.zionhuang.music.ui.component.IconButton
 import com.zionhuang.music.ui.component.LocalMenuState
 import com.zionhuang.music.ui.component.YouTubeGridItem
 import com.zionhuang.music.ui.component.YouTubeListItem
+import com.zionhuang.music.ui.component.shimmer.GridItemPlaceHolder
 import com.zionhuang.music.ui.component.shimmer.ListItemPlaceHolder
 import com.zionhuang.music.ui.component.shimmer.ShimmerHost
 import com.zionhuang.music.ui.menu.YouTubeAlbumMenu
@@ -80,6 +82,7 @@ fun ArtistItemsScreen(
     val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
 
     val lazyListState = rememberLazyListState()
+    val lazyGridState = rememberLazyGridState()
     val coroutineScope = rememberCoroutineScope()
 
     val title by viewModel.title.collectAsState()
@@ -111,6 +114,15 @@ fun ArtistItemsScreen(
     LaunchedEffect(lazyListState) {
         snapshotFlow {
             lazyListState.layoutInfo.visibleItemsInfo.any { it.key == "loading" }
+        }.collect { shouldLoadMore ->
+            if (!shouldLoadMore) return@collect
+            viewModel.loadMore()
+        }
+    }
+
+    LaunchedEffect(lazyGridState) {
+        snapshotFlow {
+            lazyGridState.layoutInfo.visibleItemsInfo.any { it.key == "loading" }
         }.collect { shouldLoadMore ->
             if (!shouldLoadMore) return@collect
             viewModel.loadMore()
@@ -208,6 +220,7 @@ fun ArtistItemsScreen(
         }
     } else {
         LazyVerticalGrid(
+            state = lazyGridState,
             columns = GridCells.Adaptive(minSize = GridThumbnailHeight + 24.dp),
             contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues()
         ) {
@@ -267,6 +280,14 @@ fun ArtistItemsScreen(
                         )
                         .animateItem()
                 )
+            }
+
+            if (itemsPage?.continuation != null) {
+                item(key = "loading") {
+                    ShimmerHost(Modifier.animateItem()) {
+                        GridItemPlaceHolder(fillMaxWidth = true)
+                    }
+                }
             }
         }
     }

--- a/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
@@ -273,7 +273,7 @@ object YouTube {
         } else {
             ArtistItemsContinuationPage(
                 items = response.continuationContents?.musicPlaylistShelfContinuation?.contents?.mapNotNull {
-                    ArtistItemsContinuationPage.fromMusicResponsiveListItemRenderer(it.musicResponsiveListItemRenderer)
+                    ArtistItemsPage.fromMusicResponsiveListItemRenderer(it.musicResponsiveListItemRenderer)
                 }!!,
                 continuation = response.continuationContents.musicPlaylistShelfContinuation.continuations?.getContinuation()
             )

--- a/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
@@ -241,7 +241,7 @@ object YouTube {
                         ArtistItemsPage.fromMusicTwoRowItemRenderer(renderer)
                     }
                 },
-                continuation = null
+                continuation = gridRenderer.continuations?.getContinuation()
             )
         } else {
             ArtistItemsPage(
@@ -260,12 +260,24 @@ object YouTube {
 
     suspend fun artistItemsContinuation(continuation: String): Result<ArtistItemsContinuationPage> = runCatching {
         val response = innerTube.browse(WEB_REMIX, continuation = continuation).body<BrowseResponse>()
-        ArtistItemsContinuationPage(
-            items = response.continuationContents?.musicPlaylistShelfContinuation?.contents?.mapNotNull {
-                ArtistItemsContinuationPage.fromMusicResponsiveListItemRenderer(it.musicResponsiveListItemRenderer)
-            }!!,
-            continuation = response.continuationContents.musicPlaylistShelfContinuation.continuations?.getContinuation()
-        )
+        val gridContinuation = response.continuationContents?.gridContinuation
+        if (gridContinuation != null) {
+            ArtistItemsContinuationPage(
+                items = gridContinuation.items.mapNotNull {
+                    it.musicTwoRowItemRenderer?.let { renderer ->
+                        ArtistItemsPage.fromMusicTwoRowItemRenderer(renderer)
+                    }
+                },
+                continuation = gridContinuation.continuations?.getContinuation()
+            )
+        } else {
+            ArtistItemsContinuationPage(
+                items = response.continuationContents?.musicPlaylistShelfContinuation?.contents?.mapNotNull {
+                    ArtistItemsContinuationPage.fromMusicResponsiveListItemRenderer(it.musicResponsiveListItemRenderer)
+                }!!,
+                continuation = response.continuationContents.musicPlaylistShelfContinuation.continuations?.getContinuation()
+            )
+        }
     }
 
     suspend fun playlist(playlistId: String): Result<PlaylistPage> = runCatching {

--- a/innertube/src/main/java/com/zionhuang/innertube/models/GridRenderer.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/GridRenderer.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 data class GridRenderer(
     val header: Header?,
     val items: List<Item>,
+    val continuations: List<Continuation>?,
 ) {
     @Serializable
     data class Header(

--- a/innertube/src/main/java/com/zionhuang/innertube/models/response/BrowseResponse.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/response/BrowseResponse.kt
@@ -2,6 +2,7 @@ package com.zionhuang.innertube.models.response
 
 import com.zionhuang.innertube.models.Button
 import com.zionhuang.innertube.models.Continuation
+import com.zionhuang.innertube.models.GridRenderer
 import com.zionhuang.innertube.models.Menu
 import com.zionhuang.innertube.models.MusicShelfRenderer
 import com.zionhuang.innertube.models.ResponseContext
@@ -49,6 +50,7 @@ data class BrowseResponse(
     data class ContinuationContents(
         val sectionListContinuation: SectionListContinuation?,
         val musicPlaylistShelfContinuation: MusicPlaylistShelfContinuation?,
+        val gridContinuation: GridContinuation?,
     ) {
         @Serializable
         data class SectionListContinuation(
@@ -59,6 +61,12 @@ data class BrowseResponse(
         @Serializable
         data class MusicPlaylistShelfContinuation(
             val contents: List<MusicShelfRenderer.Content>,
+            val continuations: List<Continuation>?,
+        )
+
+        @Serializable
+        data class GridContinuation(
+            val items: List<GridRenderer.Item>,
             val continuations: List<Continuation>?,
         )
     }

--- a/innertube/src/main/java/com/zionhuang/innertube/pages/ArtistItemsContinuationPage.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/pages/ArtistItemsContinuationPage.kt
@@ -1,46 +1,8 @@
 package com.zionhuang.innertube.pages
 
-import com.zionhuang.innertube.models.Album
-import com.zionhuang.innertube.models.Artist
-import com.zionhuang.innertube.models.MusicResponsiveListItemRenderer
-import com.zionhuang.innertube.models.SongItem
 import com.zionhuang.innertube.models.YTItem
-import com.zionhuang.innertube.models.oddElements
-import com.zionhuang.innertube.utils.parseTime
 
 data class ArtistItemsContinuationPage(
     val items: List<YTItem>,
     val continuation: String?,
-) {
-    companion object {
-        fun fromMusicResponsiveListItemRenderer(renderer: MusicResponsiveListItemRenderer): SongItem? {
-            return SongItem(
-                id = renderer.playlistItemData?.videoId ?: return null,
-                title = renderer.flexColumns.firstOrNull()
-                    ?.musicResponsiveListItemFlexColumnRenderer?.text
-                    ?.runs?.firstOrNull()?.text ?: return null,
-                artists = renderer.flexColumns.getOrNull(1)?.musicResponsiveListItemFlexColumnRenderer?.text?.runs?.oddElements()?.map {
-                    Artist(
-                        name = it.text,
-                        id = it.navigationEndpoint?.browseEndpoint?.browseId
-                    )
-                } ?: return null,
-                album = renderer.flexColumns.getOrNull(2)?.musicResponsiveListItemFlexColumnRenderer?.text?.runs?.firstOrNull()?.let {
-                    Album(
-                        name = it.text,
-                        id = it.navigationEndpoint?.browseEndpoint?.browseId ?: return null
-                    )
-                },
-                duration = renderer.fixedColumns?.firstOrNull()
-                    ?.musicResponsiveListItemFlexColumnRenderer?.text
-                    ?.runs?.firstOrNull()
-                    ?.text?.parseTime() ?: return null,
-                thumbnail = renderer.thumbnail?.musicThumbnailRenderer?.getThumbnailUrl() ?: return null,
-                explicit = renderer.badges?.find {
-                    it.musicInlineBadgeRenderer?.icon?.iconType == "MUSIC_EXPLICIT_BADGE"
-                } != null,
-                endpoint = renderer.overlay?.musicItemThumbnailOverlayRenderer?.content?.musicPlayButtonRenderer?.playNavigationEndpoint?.watchEndpoint
-            )
-        }
-    }
-}
+)


### PR DESCRIPTION
These changes make it possible to load:
- more than 100 songs on an artists page
- more than 100 albums on an artists page

Also it removes duplicate code in `ArtistItemsContinuationPage`.

There is still room for optimization. For example in `ArtistItemsScreen` we now always call two `LaunchedEffect` (for `lazyListState` and `lazyGridState`).
I don't know how much worse this is for performance.
We could do this conditionally but since I'm still learning and never used Compose before I'm not feeling confident yet doing changes in this part of the code.
Maybe someone else can work on that or I might open a separate draft PR for optimizations.

Also the initial loading placeholders are still not correct. For example when loading albums (displayed in a grid) it still initially shows list item placeholders (because it doesn't know yet that it should display a grid).
Looks a bit weird. But nothing new, this already happened before this PR so I would not change it here. Maybe something for later.