### PR TITLE
Add NewPipeExtractor for stream extraction

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -79,3 +79,10 @@
 -keep class com.my.kizzy.remote.** { <fields>; }
 # Keep Gateway data classes
 -keep class com.my.kizzy.gateway.entities.** { <fields>; }
+
+## Rules for NewPipeExtractor
+-keep class org.schabi.newpipe.extractor.timeago.patterns.** { *; }
+-keep class org.mozilla.javascript.** { *; }
+-keep class org.mozilla.classfile.ClassFileWriter
+-dontwarn org.mozilla.javascript.JavaToJSONConverters
+-dontwarn org.mozilla.javascript.tools.**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,6 +89,8 @@ firebase-perf-plugin = { module = "com.google.firebase:perf-plugin", version = "
 mlkit-language-id = { group = "com.google.mlkit", name = "language-id", version = "17.0.6" }
 mlkit-translate = { group = "com.google.mlkit", name = "translate", version = "17.0.3" }
 
+newpipe-extractor = { group = "com.github.TeamNewPipe", name = "NewPipeExtractor", version = "v0.24.3" }
+
 [plugins]
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/innertube/build.gradle.kts
+++ b/innertube/build.gradle.kts
@@ -15,5 +15,6 @@ dependencies {
     implementation(libs.ktor.serialization.json)
     implementation(libs.ktor.client.encoding)
     implementation(libs.brotli)
+    implementation(libs.newpipe.extractor)
     testImplementation(libs.junit)
 }

--- a/innertube/src/main/java/com/zionhuang/innertube/NewPipeDownloaderImpl.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/NewPipeDownloaderImpl.kt
@@ -1,0 +1,64 @@
+package com.zionhuang.innertube
+
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.schabi.newpipe.extractor.downloader.Downloader
+import org.schabi.newpipe.extractor.downloader.Request
+import org.schabi.newpipe.extractor.downloader.Response
+import org.schabi.newpipe.extractor.exceptions.ReCaptchaException
+import java.io.IOException
+
+object NewPipeDownloaderImpl : Downloader() {
+
+    /**
+     * Should be the latest Firefox ESR version.
+     */
+    private const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0"
+
+    private val client = OkHttpClient.Builder().build()
+
+    @Throws(IOException::class, ReCaptchaException::class)
+    override fun execute(request: Request): Response {
+        val httpMethod = request.httpMethod()
+        val url = request.url()
+        val headers = request.headers()
+        val dataToSend = request.dataToSend()
+
+        val requestBuilder = okhttp3.Request.Builder()
+            .method(httpMethod, dataToSend?.toRequestBody())
+            .url(url)
+            .addHeader("User-Agent", USER_AGENT)
+
+        YouTube.cookie?.let {
+            requestBuilder.addHeader("Cookie", it)
+        }
+
+        headers.forEach { (headerName, headerValueList) ->
+            if (headerName == "Cookie" && YouTube.cookie != null) {
+                // Add YouTube login cookie from InnerTune to the other cookies from NewPipeExtractor
+                requestBuilder.header(headerName, (headerValueList + YouTube.cookie).joinToString("; "))
+            } else if (headerValueList.size > 1) {
+                requestBuilder.removeHeader(headerName)
+                headerValueList.forEach { headerValue ->
+                    requestBuilder.addHeader(headerName, headerValue)
+                }
+            } else if (headerValueList.size == 1) {
+                requestBuilder.header(headerName, headerValueList[0])
+            }
+        }
+
+        val response = client.newCall(requestBuilder.build()).execute()
+
+        if (response.code == 429) {
+            response.close()
+
+            throw ReCaptchaException("reCaptcha Challenge requested", url)
+        }
+
+        val responseBodyToReturn = response.body?.string()
+
+        val latestUrl = response.request.url.toString()
+        return Response(response.code, response.message, response.headers.toMultimap(), responseBodyToReturn, latestUrl)
+    }
+
+}

--- a/innertube/src/main/java/com/zionhuang/innertube/utils/Utils.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/utils/Utils.kt
@@ -1,7 +1,12 @@
 package com.zionhuang.innertube.utils
 
 import com.zionhuang.innertube.YouTube
+import com.zionhuang.innertube.models.ResponseContext
+import com.zionhuang.innertube.models.Thumbnail
+import com.zionhuang.innertube.models.Thumbnails
+import com.zionhuang.innertube.models.response.PlayerResponse
 import com.zionhuang.innertube.pages.PlaylistPage
+import org.schabi.newpipe.extractor.stream.StreamInfo
 import java.security.MessageDigest
 
 suspend fun Result<PlaylistPage>.completed() = runCatching {
@@ -47,3 +52,53 @@ fun String.parseTime(): Int? {
     }
     return null
 }
+
+/**
+ * Maps NewPipeExtractor StreamInfo to InnerTube PlayerResponse. Not a perfect match as there are
+ * some parameters missing, but this will allow us to play streams correctly.
+ */
+fun StreamInfo.mapToPlayerResponse() = PlayerResponse(
+    responseContext = ResponseContext(null, null),
+    playabilityStatus = PlayerResponse.PlayabilityStatus("OK", null),
+    playerConfig = null,
+    streamingData = PlayerResponse.StreamingData(
+        formats = null,
+        adaptiveFormats = audioStreams.map { stream ->
+            PlayerResponse.StreamingData.Format(
+                itag = stream.itag,
+                url = stream.content,
+                mimeType = "${stream.format?.mimeType}; codecs=\"${stream.codec}\"",
+                bitrate = stream.bitrate,
+                width = null,
+                height = null,
+                contentLength = stream.content.substringAfter("clen=").substringBefore("&").toLongOrNull() ?: 10000000,
+                quality = stream.quality,
+                fps = null,
+                qualityLabel = null,
+                averageBitrate = stream.averageBitrate,
+                audioQuality = null,
+                approxDurationMs = null,
+                audioSampleRate = null,
+                audioChannels = null,
+                loudnessDb = null,
+                lastModified = null,
+            )
+        },
+        expiresInSeconds = 21540 // NewPipeExtractor doesn't give us this data, but it seems to always be this value
+    ),
+    videoDetails = PlayerResponse.VideoDetails(
+        videoId = id,
+        title = name,
+        author = uploaderName,
+        channelId = uploaderUrl.removePrefix("https://www.youtube.com/channel/"),
+        lengthSeconds = duration.toString(),
+        musicVideoType = null,
+        viewCount = viewCount.toString(),
+        thumbnail = Thumbnails(
+            thumbnails = thumbnails.map {
+                Thumbnail(it.url, it.width, it.height)
+            }
+        )
+    )
+)
+


### PR DESCRIPTION
Use NewPipeExtractor as a method to obtain song info and stream URLs. Currently this is only a proof of concept.

#### Advantages
- When YouTube changes something on their end, we would just need to wait for NewPipe team to fix it and update the library in InnerTune, they usually do it really fast, in a matter of hours or a couple of days.

#### Disadvantages
- Dependency on another library, but at least it only adds one more MB of size to the APK.
- NewPipeExtractor doesn't return some data, such as the song loudness and sample rate, so this info will be missing in details and volume normalization won't work.
- Slightly more data usage, NewPipeExtractor makes more requests than we need, for example to obtain related videos. I haven't found a way to configure this.

#### To do
- Right now this PR uses NewPipeExtractor as first option just to help testing, but the idea is to only use it as a fallback.
- There should be a way to try other stream extraction methods when one returns a seemingly valid url or signatureCipher but the stream doesn't work (for example, the server returns 403). Currently, the stream extraction and the song info database saving are all done in Media3's DataSource.Factory, so this feature would have to be developed in another PR. As an idea: maybe we could do a HTTP HEAD request before returning the url to the player to see if it responds with a 200 or not?
- I think Piped fallback should be removed, all public Piped instances are not working due to YouTube actively blocking their IPs. See https://github.com/TeamPiped/Piped/issues/3658. This should also be done in another PR.

**I need testers!** Please try this with a YouTube account and age restricted content. I only tried it without logging in, my account is not age verified and I won't give Google my ID card just to try this. I added the login cookie to NewPipeExtractor requests, so I think it should work, but I'm not sure.