### PR TITLE
Change player clients & deobfuscate params with NewPipeExtractor

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -27,3 +27,26 @@ jobs:
         with:
           name: app
           path: app/build/outputs/apk/full/debug/*.apk
+
+  build-foss:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: "zulu"
+          cache: 'gradle'
+
+      - name: Build debug APK and run jvm tests
+        run: ./gradlew assembleFossDebug lintFossDebug testFossDebugUnitTest --stacktrace -DskipFormatKtlint
+        env:
+          PULL_REQUEST: 'true'
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-foss
+          path: app/build/outputs/apk/foss/debug/*.apk

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -79,3 +79,10 @@
 -keep class com.my.kizzy.remote.** { <fields>; }
 # Keep Gateway data classes
 -keep class com.my.kizzy.gateway.entities.** { <fields>; }
+
+## Rules for NewPipeExtractor
+-keep class org.schabi.newpipe.extractor.timeago.patterns.** { *; }
+-keep class org.mozilla.javascript.** { *; }
+-keep class org.mozilla.classfile.ClassFileWriter
+-dontwarn org.mozilla.javascript.JavaToJSONConverters
+-dontwarn org.mozilla.javascript.tools.**

--- a/app/src/main/java/com/zionhuang/music/App.kt
+++ b/app/src/main/java/com/zionhuang/music/App.kt
@@ -94,7 +94,11 @@ class App : Application(), ImageLoaderFactory {
             dataStore.data
                 .map { it[InnerTubeCookieKey] }
                 .distinctUntilChanged()
-                .collect { cookie ->
+                .collect { rawCookie ->
+                    // quick hack until https://github.com/z-huang/InnerTune/pull/1694 is done
+                    val isLoggedIn: Boolean = rawCookie?.contains("SAPISID") ?: false
+                    val cookie = if (isLoggedIn) rawCookie else null
+                    
                     YouTube.cookie = cookie
                 }
         }

--- a/app/src/main/java/com/zionhuang/music/playback/DownloadUtil.kt
+++ b/app/src/main/java/com/zionhuang/music/playback/DownloadUtil.kt
@@ -108,8 +108,10 @@ class DownloadUtil @Inject constructor(
             )
         }
 
-        songUrlCache[mediaId] = format.url!! to playerResponse.streamingData!!.expiresInSeconds * 1000L
-        dataSpec.withUri(format.url!!.toUri())
+        val streamUrl = playerResponse.findUrl(format.itag)
+
+        songUrlCache[mediaId] = streamUrl!! to playerResponse.streamingData!!.expiresInSeconds * 1000L
+        dataSpec.withUri(streamUrl.toUri())
     }
     val downloadNotificationHelper = DownloadNotificationHelper(context, ExoDownloadService.CHANNEL_ID)
     val downloadManager: DownloadManager = DownloadManager(context, databaseProvider, downloadCache, dataSourceFactory, Executor(Runnable::run)).apply {

--- a/app/src/main/java/com/zionhuang/music/playback/DownloadUtil.kt
+++ b/app/src/main/java/com/zionhuang/music/playback/DownloadUtil.kt
@@ -88,10 +88,7 @@ class DownloadUtil @Inject constructor(
                             AudioQuality.LOW -> -1
                         } + (if (it.mimeType.startsWith("audio/webm")) 10240 else 0) // prefer opus stream
                     }
-            }!!.let {
-                // Specify range to avoid YouTube's throttling
-                it.copy(url = "${it.url}&range=0-${it.contentLength ?: 10000000}")
-            }
+            }!!
 
         database.query {
             upsert(
@@ -108,7 +105,10 @@ class DownloadUtil @Inject constructor(
             )
         }
 
-        val streamUrl = format.findUrl()
+        val streamUrl = format.findUrl()?.let {
+            // Specify range to avoid YouTube's throttling
+            "${it}&range=0-${format.contentLength ?: 10000000}"
+        }
 
         songUrlCache[mediaId] = streamUrl!! to playerResponse.streamingData!!.expiresInSeconds * 1000L
         dataSpec.withUri(streamUrl.toUri())

--- a/app/src/main/java/com/zionhuang/music/playback/DownloadUtil.kt
+++ b/app/src/main/java/com/zionhuang/music/playback/DownloadUtil.kt
@@ -108,7 +108,7 @@ class DownloadUtil @Inject constructor(
             )
         }
 
-        val streamUrl = playerResponse.findUrl(format.itag)
+        val streamUrl = format.findUrl()
 
         songUrlCache[mediaId] = streamUrl!! to playerResponse.streamingData!!.expiresInSeconds * 1000L
         dataSpec.withUri(streamUrl.toUri())

--- a/app/src/main/java/com/zionhuang/music/playback/MusicService.kt
+++ b/app/src/main/java/com/zionhuang/music/playback/MusicService.kt
@@ -691,7 +691,7 @@ class MusicService : MediaLibraryService(),
             }
             scope.launch(Dispatchers.IO) { recoverSong(mediaId, playerResponse) }
 
-            val streamUrl = playerResponse.findUrl(format.itag)
+            val streamUrl = format.findUrl()
 
             songUrlCache[mediaId] = streamUrl!! to playerResponse.streamingData!!.expiresInSeconds * 1000L
             dataSpec.withUri(streamUrl.toUri()).subrange(dataSpec.uriPositionOffset, CHUNK_LENGTH)

--- a/app/src/main/java/com/zionhuang/music/playback/MusicService.kt
+++ b/app/src/main/java/com/zionhuang/music/playback/MusicService.kt
@@ -691,8 +691,10 @@ class MusicService : MediaLibraryService(),
             }
             scope.launch(Dispatchers.IO) { recoverSong(mediaId, playerResponse) }
 
-            songUrlCache[mediaId] = format.url!! to playerResponse.streamingData!!.expiresInSeconds * 1000L
-            dataSpec.withUri(format.url!!.toUri()).subrange(dataSpec.uriPositionOffset, CHUNK_LENGTH)
+            val streamUrl = playerResponse.findUrl(format.itag)
+
+            songUrlCache[mediaId] = streamUrl!! to playerResponse.streamingData!!.expiresInSeconds * 1000L
+            dataSpec.withUri(streamUrl.toUri()).subrange(dataSpec.uriPositionOffset, CHUNK_LENGTH)
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,6 +89,8 @@ firebase-perf-plugin = { module = "com.google.firebase:perf-plugin", version = "
 mlkit-language-id = { group = "com.google.mlkit", name = "language-id", version = "17.0.6" }
 mlkit-translate = { group = "com.google.mlkit", name = "translate", version = "17.0.3" }
 
+newpipe-extractor = { group = "com.github.TeamNewPipe", name = "NewPipeExtractor", version = "v0.24.3" }
+
 [plugins]
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,7 +89,9 @@ firebase-perf-plugin = { module = "com.google.firebase:perf-plugin", version = "
 mlkit-language-id = { group = "com.google.mlkit", name = "language-id", version = "17.0.6" }
 mlkit-translate = { group = "com.google.mlkit", name = "translate", version = "17.0.3" }
 
-newpipe-extractor = { group = "com.github.TeamNewPipe", name = "NewPipeExtractor", version = "v0.24.3" }
+#newpipe-extractor = { group = "com.github.TeamNewPipe", name = "NewPipeExtractor", version = "v0.24.3" }
+# Use fork of NewPipeExtractor until https://github.com/TeamNewPipe/NewPipeExtractor/pull/1253 is merged
+newpipe-extractor = { group = "com.github.gechoto", name = "NewPipeExtractor", version = "0a5158d9052d57a9dbf184814de1988a8cb7824d" }
 
 [plugins]
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/innertube/build.gradle.kts
+++ b/innertube/build.gradle.kts
@@ -15,5 +15,6 @@ dependencies {
     implementation(libs.ktor.serialization.json)
     implementation(libs.ktor.client.encoding)
     implementation(libs.brotli)
+    implementation(libs.newpipe.extractor)
     testImplementation(libs.junit)
 }

--- a/innertube/src/main/java/com/zionhuang/innertube/InnerTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/InnerTube.kt
@@ -98,9 +98,6 @@ class InnerTube {
             }
         }
         userAgent(client.userAgent)
-        if (client.api_key != null) {
-            parameter("key", client.api_key)
-        }
         parameter("prettyPrint", false)
     }
 
@@ -233,7 +230,6 @@ class InnerTube {
         client: YouTubeClient,
         videoId: String,
     ) = httpClient.post("https://music.youtube.com/youtubei/v1/get_transcript") {
-        parameter("key", "AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX3")
         headers {
             append("Content-Type", "application/json")
         }

--- a/innertube/src/main/java/com/zionhuang/innertube/InnerTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/InnerTube.kt
@@ -88,7 +88,7 @@ class InnerTube {
             if (client.referer != null) {
                 append("Referer", client.referer)
             }
-            if (setLogin) {
+            if (setLogin && client.supportsLogin) {
                 cookie?.let { cookie ->
                     append("cookie", cookie)
                     if ("SAPISID" !in cookieMap) return@let

--- a/innertube/src/main/java/com/zionhuang/innertube/InnerTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/InnerTube.kt
@@ -85,7 +85,6 @@ class InnerTube {
             append("X-Goog-Api-Format-Version", "1")
             append("X-YouTube-Client-Name", client.clientId)
             append("X-YouTube-Client-Version", client.clientVersion)
-            append("X-Goog-Visitor-Id", visitorData)
             append("X-Origin", YouTubeClient.ORIGIN_YOUTUBE_MUSIC)
             append("Referer", YouTubeClient.REFERER_YOUTUBE_MUSIC)
             if (setLogin && client.supportsLogin) {

--- a/innertube/src/main/java/com/zionhuang/innertube/InnerTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/InnerTube.kt
@@ -18,6 +18,7 @@ import io.ktor.serialization.kotlinx.json.*
 import io.ktor.util.encodeBase64
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
+import org.schabi.newpipe.extractor.services.youtube.YoutubeJavaScriptPlayerManager
 import java.net.Proxy
 import java.util.*
 
@@ -74,7 +75,7 @@ class InnerTube {
         }
 
         defaultRequest {
-            url("https://music.youtube.com/youtubei/v1/")
+            url(YouTubeClient.API_URL_YOUTUBE_MUSIC)
         }
     }
 
@@ -82,24 +83,25 @@ class InnerTube {
         contentType(ContentType.Application.Json)
         headers {
             append("X-Goog-Api-Format-Version", "1")
-            append("X-YouTube-Client-Name", client.clientName)
+            append("X-YouTube-Client-Name", client.clientId)
             append("X-YouTube-Client-Version", client.clientVersion)
-            append("x-origin", "https://music.youtube.com")
-            if (client.referer != null) {
-                append("Referer", client.referer)
-            }
+            append("X-Goog-Visitor-Id", visitorData)
+            append("X-Origin", YouTubeClient.ORIGIN_YOUTUBE_MUSIC)
+            append("Referer", YouTubeClient.REFERER_YOUTUBE_MUSIC)
             if (setLogin && client.supportsLogin) {
                 cookie?.let { cookie ->
                     append("cookie", cookie)
                     if ("SAPISID" !in cookieMap) return@let
                     val currentTime = System.currentTimeMillis() / 1000
-                    val sapisidHash = sha1("$currentTime ${cookieMap["SAPISID"]} https://music.youtube.com")
+                    val sapisidHash = sha1("$currentTime ${cookieMap["SAPISID"]} ${YouTubeClient.ORIGIN_YOUTUBE_MUSIC}")
                     append("Authorization", "SAPISIDHASH ${currentTime}_${sapisidHash}")
                 }
             }
         }
         userAgent(client.userAgent)
-        parameter("key", client.api_key)
+        if (client.api_key != null) {
+            parameter("key", client.api_key)
+        }
         parameter("prettyPrint", false)
     }
 
@@ -139,7 +141,13 @@ class InnerTube {
                     } else it
                 },
                 videoId = videoId,
-                playlistId = playlistId
+                playlistId = playlistId,
+                playbackContext =
+                    if (client.useSignatureTimestamp) {
+                        PlayerBody.PlaybackContext(PlayerBody.PlaybackContext.ContentPlaybackContext(
+                            signatureTimestamp = YoutubeJavaScriptPlayerManager.getSignatureTimestamp("")
+                        ))
+                    } else null
             )
         )
     }

--- a/innertube/src/main/java/com/zionhuang/innertube/InnerTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/InnerTube.kt
@@ -144,7 +144,7 @@ class InnerTube {
                 playbackContext =
                     if (client.useSignatureTimestamp) {
                         PlayerBody.PlaybackContext(PlayerBody.PlaybackContext.ContentPlaybackContext(
-                            signatureTimestamp = YoutubeJavaScriptPlayerManager.getSignatureTimestamp("")
+                            signatureTimestamp = YoutubeJavaScriptPlayerManager.getSignatureTimestamp(videoId)
                         ))
                     } else null
             )

--- a/innertube/src/main/java/com/zionhuang/innertube/NewPipeDownloaderImpl.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/NewPipeDownloaderImpl.kt
@@ -1,0 +1,57 @@
+package com.zionhuang.innertube
+
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.schabi.newpipe.extractor.downloader.Downloader
+import org.schabi.newpipe.extractor.downloader.Request
+import org.schabi.newpipe.extractor.downloader.Response
+import org.schabi.newpipe.extractor.exceptions.ReCaptchaException
+import java.io.IOException
+
+object NewPipeDownloaderImpl : Downloader() {
+
+    /**
+     * Should be the latest Firefox ESR version.
+     */
+    private const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0"
+
+    private val client = OkHttpClient.Builder().build()
+
+    @Throws(IOException::class, ReCaptchaException::class)
+    override fun execute(request: Request): Response {
+        val httpMethod = request.httpMethod()
+        val url = request.url()
+        val headers = request.headers()
+        val dataToSend = request.dataToSend()
+
+        val requestBuilder = okhttp3.Request.Builder()
+            .method(httpMethod, dataToSend?.toRequestBody())
+            .url(url)
+            .addHeader("User-Agent", USER_AGENT)
+
+        headers.forEach { (headerName, headerValueList) ->
+            if (headerValueList.size > 1) {
+                requestBuilder.removeHeader(headerName)
+                headerValueList.forEach { headerValue ->
+                    requestBuilder.addHeader(headerName, headerValue)
+                }
+            } else if (headerValueList.size == 1) {
+                requestBuilder.header(headerName, headerValueList[0])
+            }
+        }
+
+        val response = client.newCall(requestBuilder.build()).execute()
+
+        if (response.code == 429) {
+            response.close()
+
+            throw ReCaptchaException("reCaptcha Challenge requested", url)
+        }
+
+        val responseBodyToReturn = response.body?.string()
+
+        val latestUrl = response.request.url.toString()
+        return Response(response.code, response.message, response.headers.toMultimap(), responseBodyToReturn, latestUrl)
+    }
+
+}

--- a/innertube/src/main/java/com/zionhuang/innertube/NewPipeDownloaderImpl.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/NewPipeDownloaderImpl.kt
@@ -1,5 +1,6 @@
 package com.zionhuang.innertube
 
+import com.zionhuang.innertube.models.YouTubeClient
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.schabi.newpipe.extractor.downloader.Downloader
@@ -9,11 +10,6 @@ import org.schabi.newpipe.extractor.exceptions.ReCaptchaException
 import java.io.IOException
 
 object NewPipeDownloaderImpl : Downloader() {
-
-    /**
-     * Should be the latest Firefox ESR version.
-     */
-    private const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0"
 
     private val client = OkHttpClient.Builder().build()
 
@@ -27,7 +23,7 @@ object NewPipeDownloaderImpl : Downloader() {
         val requestBuilder = okhttp3.Request.Builder()
             .method(httpMethod, dataToSend?.toRequestBody())
             .url(url)
-            .addHeader("User-Agent", USER_AGENT)
+            .addHeader("User-Agent", YouTubeClient.USER_AGENT_WEB)
 
         headers.forEach { (headerName, headerValueList) ->
             if (headerValueList.size > 1) {

--- a/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
@@ -12,7 +12,6 @@ import com.zionhuang.innertube.models.SearchSuggestions
 import com.zionhuang.innertube.models.SongItem
 import com.zionhuang.innertube.models.WatchEndpoint
 import com.zionhuang.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.Companion.MUSIC_VIDEO_TYPE_ATV
-import com.zionhuang.innertube.models.YouTubeClient.Companion.ANDROID_MUSIC
 import com.zionhuang.innertube.models.YouTubeClient.Companion.IOS
 import com.zionhuang.innertube.models.YouTubeClient.Companion.TVHTML5
 import com.zionhuang.innertube.models.YouTubeClient.Companion.WEB

--- a/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
@@ -448,7 +448,7 @@ object YouTube {
         }
         val safePlayerResponse = innerTube.player(TVHTML5, videoId, playlistId).body<PlayerResponse>()
         if (safePlayerResponse.playabilityStatus.status != "OK") {
-            return@runCatching safePlayerResponse
+            return@runCatching playerResponse
         }
         val audioStreams = innerTube.pipedStreams(videoId).body<PipedResponse>().audioStreams
         safePlayerResponse.copy(

--- a/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
@@ -15,6 +15,7 @@ import com.zionhuang.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedC
 import com.zionhuang.innertube.models.YouTubeClient.Companion.IOS
 import com.zionhuang.innertube.models.YouTubeClient.Companion.TVHTML5
 import com.zionhuang.innertube.models.YouTubeClient.Companion.WEB
+import com.zionhuang.innertube.models.YouTubeClient.Companion.WEB_CREATOR
 import com.zionhuang.innertube.models.YouTubeClient.Companion.WEB_REMIX
 import com.zionhuang.innertube.models.YouTubeLocale
 import com.zionhuang.innertube.models.getContinuation
@@ -435,8 +436,8 @@ object YouTube {
 
     suspend fun player(videoId: String, playlistId: String? = null): Result<PlayerResponse> = runCatching {
         var playerResponse: PlayerResponse
-        if (this.cookie != null) { // if logged in: try WEB_REMIX client first because IOS client does not support login
-            playerResponse = innerTube.player(WEB_REMIX, videoId, playlistId).body<PlayerResponse>()
+        if (this.cookie != null) { // if logged in: try WEB_CREATOR client first because IOS client does not support login
+            playerResponse = innerTube.player(WEB_CREATOR, videoId, playlistId).body<PlayerResponse>()
             if (playerResponse.playabilityStatus.status == "OK") {
                 return@runCatching playerResponse
             }

--- a/innertube/src/main/java/com/zionhuang/innertube/models/YouTubeClient.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/YouTubeClient.kt
@@ -35,20 +35,6 @@ data class YouTubeClient(
         const val REFERER_YOUTUBE_MUSIC = "$ORIGIN_YOUTUBE_MUSIC/"
         const val API_URL_YOUTUBE_MUSIC = "$ORIGIN_YOUTUBE_MUSIC/youtubei/v1/"
 
-//        private const val USER_AGENT_ANDROID = "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Mobile Safari/537.36"
-//        val ANDROID_MUSIC = YouTubeClient(
-//            clientName = "ANDROID_MUSIC",
-//            clientVersion = "5.01",
-//            api_key = "AIzaSyAOghZGza2MQSZkY_zfZ370N-PUdXEo8AI",
-//            userAgent = USER_AGENT_ANDROID,
-//        )
-//        val ANDROID = YouTubeClient(
-//            clientName = "ANDROID",
-//            clientVersion = "17.13.3",
-//            api_key = "AIzaSyA8eiZmM1FaDVjRy-df2KTyQ_vz_yYM39w",
-//            userAgent = USER_AGENT_ANDROID,
-//        )
-
         val WEB = YouTubeClient(
             clientName = "WEB",
             clientVersion = "2.20241126.01.00",

--- a/innertube/src/main/java/com/zionhuang/innertube/models/YouTubeClient.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/YouTubeClient.kt
@@ -10,6 +10,7 @@ data class YouTubeClient(
     val userAgent: String,
     val osVersion: String? = null,
     val referer: String? = null,
+    val supportsLogin: Boolean = false,
 ) {
     fun toContext(locale: YouTubeLocale, visitorData: String?) = Context(
         client = Context.Client(
@@ -25,15 +26,14 @@ data class YouTubeClient(
     companion object {
         private const val REFERER_YOUTUBE_MUSIC = "https://music.youtube.com/"
 
-        private const val USER_AGENT_WEB = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36"
+        private const val USER_AGENT_WEB = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.107 Safari/537.36"
         private const val USER_AGENT_ANDROID = "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Mobile Safari/537.36"
-        private const val USER_AGENT_IOS = "com.google.ios.youtube/19.29.1 (iPhone16,2; U; CPU iOS 17_5_1 like Mac OS X;)"
 
         val ANDROID_MUSIC = YouTubeClient(
             clientName = "ANDROID_MUSIC",
             clientVersion = "5.01",
             api_key = "AIzaSyAOghZGza2MQSZkY_zfZ370N-PUdXEo8AI",
-            userAgent = USER_AGENT_ANDROID
+            userAgent = USER_AGENT_ANDROID,
         )
 
         val ANDROID = YouTubeClient(
@@ -47,30 +47,31 @@ data class YouTubeClient(
             clientName = "WEB",
             clientVersion = "2.2021111",
             api_key = "AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX3",
-            userAgent = USER_AGENT_WEB
+            userAgent = USER_AGENT_WEB,
         )
 
         val WEB_REMIX = YouTubeClient(
             clientName = "WEB_REMIX",
-            clientVersion = "1.20220606.03.00",
-            api_key = "AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX30",
+            clientVersion = "1.20241127.01.00",
+            api_key = "AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX30", // TODO: remove
             userAgent = USER_AGENT_WEB,
-            referer = REFERER_YOUTUBE_MUSIC
+            referer = REFERER_YOUTUBE_MUSIC,
+            supportsLogin = true,
         )
 
         val TVHTML5 = YouTubeClient(
             clientName = "TVHTML5_SIMPLY_EMBEDDED_PLAYER",
             clientVersion = "2.0",
             api_key = "AIzaSyDCU8hByM-4DrUqRUYnGn-3llEO78bcxq8",
-            userAgent = "Mozilla/5.0 (PlayStation 4 5.55) AppleWebKit/601.2 (KHTML, like Gecko)"
+            userAgent = "Mozilla/5.0 (PlayStation 4 5.55) AppleWebKit/601.2 (KHTML, like Gecko)",
         )
 
         val IOS = YouTubeClient(
             clientName = "IOS",
-            clientVersion = "19.29.1",
-            api_key = "AIzaSyB-63vPrdThhKuerbB2N_l7Kwwcxj6yUAc",
-            userAgent = USER_AGENT_IOS,
-            osVersion = "17.5.1.21F90",
+            clientVersion = "19.45.4",
+            api_key = "AIzaSyB-63vPrdThhKuerbB2N_l7Kwwcxj6yUAc", // TODO: remove
+            userAgent = "com.google.ios.youtube/19.45.4 (iPhone16,2; U; CPU iOS 18_1_0 like Mac OS X;)",
+            osVersion = "18.1.0.22B83",
         )
     }
 }

--- a/innertube/src/main/java/com/zionhuang/innertube/models/YouTubeClient.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/YouTubeClient.kt
@@ -80,8 +80,9 @@ data class YouTubeClient(
             clientName = "TVHTML5_SIMPLY_EMBEDDED_PLAYER",
             clientVersion = "2.0",
             clientId = "85",
-            api_key = "AIzaSyDCU8hByM-4DrUqRUYnGn-3llEO78bcxq8",
-            userAgent = "Mozilla/5.0 (PlayStation 4 5.55) AppleWebKit/601.2 (KHTML, like Gecko)",
+            userAgent = "Mozilla/5.0 (PlayStation; PlayStation 4/12.00) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Safari/605.1.15",
+            supportsLogin = true,
+            useSignatureTimestamp = true,
         )
 
         val IOS = YouTubeClient(

--- a/innertube/src/main/java/com/zionhuang/innertube/models/YouTubeClient.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/YouTubeClient.kt
@@ -7,7 +7,6 @@ data class YouTubeClient(
     val clientName: String,
     val clientVersion: String,
     val clientId: String,
-    val api_key: String? = null,
     val userAgent: String,
     val osVersion: String? = null,
     val supportsLogin: Boolean = false,
@@ -54,7 +53,6 @@ data class YouTubeClient(
             clientName = "WEB",
             clientVersion = "2.20241126.01.00",
             clientId = "1",
-            api_key = "AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX3",
             userAgent = USER_AGENT_WEB,
         )
 

--- a/innertube/src/main/java/com/zionhuang/innertube/models/YouTubeClient.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/YouTubeClient.kt
@@ -6,11 +6,14 @@ import kotlinx.serialization.Serializable
 data class YouTubeClient(
     val clientName: String,
     val clientVersion: String,
-    val api_key: String,
+    val clientId: String,
+    val api_key: String? = null,
     val userAgent: String,
     val osVersion: String? = null,
-    val referer: String? = null,
     val supportsLogin: Boolean = false,
+    val useSignatureTimestamp: Boolean = false,
+    // val origin: String? = null,
+    // val referer: String? = null,
 ) {
     fun toContext(locale: YouTubeLocale, visitorData: String?) = Context(
         client = Context.Client(
@@ -24,28 +27,33 @@ data class YouTubeClient(
     )
 
     companion object {
-        private const val REFERER_YOUTUBE_MUSIC = "https://music.youtube.com/"
+        /**
+         * Should be the latest Firefox ESR version.
+         */
+        const val USER_AGENT_WEB = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0"
 
-        private const val USER_AGENT_WEB = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.107 Safari/537.36"
-        private const val USER_AGENT_ANDROID = "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Mobile Safari/537.36"
+        const val ORIGIN_YOUTUBE_MUSIC = "https://music.youtube.com"
+        const val REFERER_YOUTUBE_MUSIC = "$ORIGIN_YOUTUBE_MUSIC/"
+        const val API_URL_YOUTUBE_MUSIC = "$ORIGIN_YOUTUBE_MUSIC/youtubei/v1/"
 
-        val ANDROID_MUSIC = YouTubeClient(
-            clientName = "ANDROID_MUSIC",
-            clientVersion = "5.01",
-            api_key = "AIzaSyAOghZGza2MQSZkY_zfZ370N-PUdXEo8AI",
-            userAgent = USER_AGENT_ANDROID,
-        )
-
-        val ANDROID = YouTubeClient(
-            clientName = "ANDROID",
-            clientVersion = "17.13.3",
-            api_key = "AIzaSyA8eiZmM1FaDVjRy-df2KTyQ_vz_yYM39w",
-            userAgent = USER_AGENT_ANDROID,
-        )
+//        private const val USER_AGENT_ANDROID = "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Mobile Safari/537.36"
+//        val ANDROID_MUSIC = YouTubeClient(
+//            clientName = "ANDROID_MUSIC",
+//            clientVersion = "5.01",
+//            api_key = "AIzaSyAOghZGza2MQSZkY_zfZ370N-PUdXEo8AI",
+//            userAgent = USER_AGENT_ANDROID,
+//        )
+//        val ANDROID = YouTubeClient(
+//            clientName = "ANDROID",
+//            clientVersion = "17.13.3",
+//            api_key = "AIzaSyA8eiZmM1FaDVjRy-df2KTyQ_vz_yYM39w",
+//            userAgent = USER_AGENT_ANDROID,
+//        )
 
         val WEB = YouTubeClient(
             clientName = "WEB",
-            clientVersion = "2.2021111",
+            clientVersion = "2.20241126.01.00",
+            clientId = "1",
             api_key = "AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX3",
             userAgent = USER_AGENT_WEB,
         )
@@ -53,15 +61,24 @@ data class YouTubeClient(
         val WEB_REMIX = YouTubeClient(
             clientName = "WEB_REMIX",
             clientVersion = "1.20241127.01.00",
-            api_key = "AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX30", // TODO: remove
+            clientId = "67",
             userAgent = USER_AGENT_WEB,
-            referer = REFERER_YOUTUBE_MUSIC,
             supportsLogin = true,
+        )
+
+        val WEB_CREATOR = YouTubeClient(
+            clientName = "WEB_CREATOR",
+            clientVersion = "1.20241203.01.00",
+            clientId = "62",
+            userAgent = USER_AGENT_WEB,
+            supportsLogin = true,
+            useSignatureTimestamp = true,
         )
 
         val TVHTML5 = YouTubeClient(
             clientName = "TVHTML5_SIMPLY_EMBEDDED_PLAYER",
             clientVersion = "2.0",
+            clientId = "85",
             api_key = "AIzaSyDCU8hByM-4DrUqRUYnGn-3llEO78bcxq8",
             userAgent = "Mozilla/5.0 (PlayStation 4 5.55) AppleWebKit/601.2 (KHTML, like Gecko)",
         )
@@ -69,7 +86,7 @@ data class YouTubeClient(
         val IOS = YouTubeClient(
             clientName = "IOS",
             clientVersion = "19.45.4",
-            api_key = "AIzaSyB-63vPrdThhKuerbB2N_l7Kwwcxj6yUAc", // TODO: remove
+            clientId = "5",
             userAgent = "com.google.ios.youtube/19.45.4 (iPhone16,2; U; CPU iOS 18_1_0 like Mac OS X;)",
             osVersion = "18.1.0.22B83",
         )

--- a/innertube/src/main/java/com/zionhuang/innertube/models/YouTubeClient.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/YouTubeClient.kt
@@ -64,6 +64,7 @@ data class YouTubeClient(
             clientId = "67",
             userAgent = USER_AGENT_WEB,
             supportsLogin = true,
+            useSignatureTimestamp = true,
         )
 
         val WEB_CREATOR = YouTubeClient(

--- a/innertube/src/main/java/com/zionhuang/innertube/models/body/PlayerBody.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/body/PlayerBody.kt
@@ -8,5 +8,17 @@ data class PlayerBody(
     val context: Context,
     val videoId: String,
     val playlistId: String?,
+    val playbackContext: PlaybackContext? = null,
     val contentCheckOk: Boolean = true,
-)
+    val racyCheckOk: Boolean = true,
+) {
+    @Serializable
+    data class PlaybackContext(
+        val contentPlaybackContext: ContentPlaybackContext
+    ) {
+        @Serializable
+        data class ContentPlaybackContext(
+            val signatureTimestamp: Int
+        )
+    }
+}

--- a/innertube/src/main/java/com/zionhuang/innertube/models/response/PlayerResponse.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/response/PlayerResponse.kt
@@ -75,8 +75,7 @@ data class PlayerResponse(
                     val signatureParam = params["sp"] ?: return null
                     val url = params["url"]?.let { URLBuilder(it) } ?: return null
                     url.parameters[signatureParam] = YoutubeJavaScriptPlayerManager.deobfuscateSignature("", obfuscatedSignature)
-                    val streamUrl = YoutubeJavaScriptPlayerManager.getUrlWithThrottlingParameterDeobfuscated("", url.toString())
-                    return streamUrl
+                    return YoutubeJavaScriptPlayerManager.getUrlWithThrottlingParameterDeobfuscated("", url.toString())
                 }
                 return null
             }

--- a/innertube/src/main/java/com/zionhuang/innertube/models/response/PlayerResponse.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/response/PlayerResponse.kt
@@ -84,7 +84,7 @@ data class PlayerResponse(
             if (format.url != null) {
                 return format.url
             }
-            if (this.videoDetails?.videoId != null && format.signatureCipher != null) {
+            if (format.signatureCipher != null) {
                 val params = parseQueryString(format.signatureCipher)
                 val obfuscatedSignature = params["s"] ?: return null
                 val signatureParam = params["sp"] ?: return null

--- a/innertube/src/main/java/com/zionhuang/innertube/models/response/PlayerResponse.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/response/PlayerResponse.kt
@@ -81,11 +81,11 @@ data class PlayerResponse(
 
     fun findUrl(itag: Int): String? {
         this.streamingData?.adaptiveFormats?.find { it.itag == itag }?.let { format ->
-            if (format.url != null) {
-                return format.url
+            format.url?.let {
+                return it
             }
-            if (format.signatureCipher != null) {
-                val params = parseQueryString(format.signatureCipher)
+            format.signatureCipher?.let { signatureCipher ->
+                val params = parseQueryString(signatureCipher)
                 val obfuscatedSignature = params["s"] ?: return null
                 val signatureParam = params["sp"] ?: return null
                 val url = params["url"]?.let { URLBuilder(it) } ?: return null


### PR DESCRIPTION
Should fix https://github.com/z-huang/InnerTune/issues/1748 https://github.com/z-huang/InnerTune/issues/1781 https://github.com/z-huang/InnerTune/issues/1775 https://github.com/z-huang/InnerTune/issues/1770 https://github.com/z-huang/InnerTune/issues/1758 https://github.com/z-huang/InnerTune/issues/1764 https://github.com/z-huang/InnerTune/issues/1760 https://github.com/z-huang/InnerTune/issues/1757

Changes:
- Use WEB_CREATOR client for logged in player requests
- Use NewPipeExtractor to deobfuscate signature and throttling parameter
- Send login only for clients which support it (IOS client doesn't support it anymore)
- Update clients
- Workaround until https://github.com/z-huang/InnerTune/pull/1694 is done

Disadvantages:
- Premium audio formats don't work currently. The WEB_CREATOR client doesn't support them. There could be something added later to try with the WEB_REMIX client for premium users first.