### PR TITLE
cleanup untranslated strings from translation files

### DIFF
--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -263,8 +263,4 @@
 
     <string name="about">সম্পর্কিত</string>
     <string name="app_version">অ্যাপ সংস্করণ</string>
-
-    <string name="new_version_available">New version available</string>
-    <string name="translation_models">Translation Models</string>
-    <string name="clear_translation_models">Clear translation models</string>
 </resources>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -94,7 +94,6 @@
     <string name="mime_type">MIME-tyyppi</string>
     <string name="codecs">Koodekit</string>
     <string name="bitrate">Bittinopeus</string>
-    <string name="sample_rate">Sample rate</string>
     <string name="loudness">Äänekkyys</string>
     <string name="volume">Voimakkuus</string>
     <string name="file_size">Tiedoston koko</string>
@@ -176,7 +175,6 @@
     <string name="repeat_mode_all">Toista jono</string>
     <!-- Queue Title -->
     <string name="queue_all_songs">Kaikki laulut</string>
-    <string name="queue_searched_songs">Searched songs</string>
 
     <!-- Notification name -->
     <string name="music_player">Soitin</string>
@@ -184,75 +182,18 @@
     <!-- Settings -->
     <string name="settings">Asetukset</string>
     <string name="appearance">Ulkoasu</string>
-    <string name="enable_dynamic_theme">Enable dynamic theme</string>
     <string name="dark_theme">Tumma teema</string>
     <string name="dark_theme_on">Käytössä</string>
     <string name="dark_theme_off">Pois käytöstä</string>
     <string name="dark_theme_follow_system">Järjestelmän teeman mukainen</string>
-    <string name="pure_black">Pure black</string>
-    <string name="default_open_tab">Default open tab</string>
-    <string name="customize_navigation_tabs">Customize navigation tabs</string>
-    <string name="lyrics_text_position">Lyrics text position</string>
-    <string name="left">Left</string>
-    <string name="center">Center</string>
-    <string name="right">Right</string>
 
     <string name="content">Sisältö</string>
-    <string name="login">Login</string>
     <string name="content_language">Sisällön oletuskieli</string>
     <string name="content_country">Sisällön oletusmaa</string>
     <string name="system_default">Järjestelmän oletus</string>
-    <string name="enable_proxy">Enable proxy</string>
-    <string name="proxy_type">Proxy type</string>
-    <string name="proxy_url">Proxy URL</string>
-    <string name="restart_to_take_effect">Restart to take effect</string>
-
-    <string name="player_and_audio">Player and audio</string>
-    <string name="audio_quality">Audio quality</string>
-    <string name="audio_quality_auto">Auto</string>
-    <string name="audio_quality_high">High</string>
-    <string name="audio_quality_low">Low</string>
-    <string name="persistent_queue">Persistent queue</string>
-    <string name="skip_silence">Skip silence</string>
-    <string name="audio_normalization">Audio normalization</string>
-    <string name="equalizer">Equalizer</string>
-
-    <string name="storage">Storage</string>
-    <string name="cache">Cache</string>
-    <string name="image_cache">Image Cache</string>
-    <string name="song_cache">Song Cache</string>
-    <string name="max_cache_size">Max cache size</string>
-    <string name="unlimited">Unlimited</string>
-    <string name="clear_all_downloads">Clear all downloads</string>
-    <string name="max_image_cache_size">Max image cache size</string>
-    <string name="clear_image_cache">Clear image cache</string>
-    <string name="max_song_cache_size">Max song cache size</string>
-    <string name="clear_song_cache">Clear song cache</string>
-    <string name="size_used">%s used</string>
-
-    <string name="privacy">Privacy</string>
-    <string name="pause_listen_history">Pause listen history</string>
-    <string name="clear_listen_history">Clear listen history</string>
-    <string name="clear_listen_history_confirm">Are you sure to clear all listen history?</string>
-    <string name="pause_search_history">Pause search history</string>
-    <string name="clear_search_history">Clear search history</string>
-    <string name="clear_search_history_confirm">Are you sure to clear all search history?</string>
-    <string name="enable_kugou">Enable KuGou lyrics provider</string>
-
-    <string name="backup_restore">Backup and restore</string>
-    <string name="backup">Backup</string>
-    <string name="restore">Restore</string>
-    <string name="imported_playlist">Imported playlist</string>
-    <string name="backup_create_success">Backup created successfully</string>
-    <string name="backup_create_failed">Couldn\'t create backup</string>
-    <string name="restore_failed">Failed to restore backup</string>
-
     <string name="about">Tietoa</string>
     <string name="app_version">Sovelluksen versio</string>
 
-    <string name="new_version_available">New version available</string>
-    <string name="translation_models">Translation Models</string>
-    <string name="clear_translation_models">Clear translation models</string>
     <string name="add_all_to_library">Lisää kaikki kirjastoon</string>
     <string name="remove_all_from_library">Poista kaikki kirjastosta</string>
     <string name="remove_from_queue">Poista jonosta</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -12,29 +12,10 @@
         <item quantity="other">%d തിരഞ്ഞെടുത്തു</item>
     </plurals>
     <!-- Home -->
-    <string name="history">History</string>
-    <string name="stats">Stats</string>
-    <string name="mood_and_genres">Mood and Genres</string>
-    <string name="account">Account</string>
-    <string name="quick_picks">Quick picks</string>
-    <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">New release albums</string>
-    <!-- History -->
-    <string name="today">Today</string>
-    <string name="yesterday">Yesterday</string>
-    <string name="this_week">This week</string>
-    <string name="last_week">Last week</string>
-    <!-- Stats -->
-    <string name="most_played_songs">Most played songs</string>
-    <string name="most_played_artists">Most played artists</string>
-    <string name="most_played_albums">Most played albums</string>
     <!-- Search -->
     <string name="search">തിരയുക</string>
     <string name="search_yt_music">യൂട്യൂബ് സംഗീതം തിരയുക…</string>
     <string name="search_library">തിരയൽ ലൈബ്രറി…</string>
-    <string name="filter_library">Library</string>
-    <string name="filter_liked">Liked</string>
-    <string name="filter_downloaded">Downloaded</string>
     <string name="filter_all">എല്ലാം</string>
     <string name="filter_songs">പാട്ടുകൾ</string>
     <string name="filter_videos">വീഡിയോകൾ</string>
@@ -43,30 +24,23 @@
     <string name="filter_playlists">പ്ലേലിസ്റ്റുകൾ</string>
     <string name="filter_community_playlists">കമ്മ്യൂണിറ്റി പ്ലേലിസ്റ്റുകൾ</string>
     <string name="filter_featured_playlists">തിരഞ്ഞെടുത്ത പ്ലേലിസ്റ്റുകൾ</string>
-    <string name="filter_bookmarked">Bookmarked</string>
-    <string name="no_results_found">No results found</string>
     <!-- Artist screen -->
     <string name="from_your_library">നിങ്ങളുടെ ലൈബ്രറിയിൽ നിന്ന്</string>
     <!-- Playlist -->
     <string name="liked_songs">ഇഷ്ടപ്പെട്ട പാട്ടുകൾ</string>
     <string name="downloaded_songs">ഡൗൺലോഡ് ചെയ്‌ത പാട്ടുകൾ</string>
-    <string name="playlist_is_empty">The playlist is empty</string>
     <!-- Button -->
     <string name="retry">വീണ്ടും ശ്രമിക്കുക</string>
     <string name="radio">റേഡിയോ</string>
     <string name="shuffle">ഷഫിൾ</string>
-    <string name="reset">Reset</string>
     <!-- Menu -->
-    <string name="details">Details</string>
     <string name="edit">എഡിറ്റ് ചെയ്യുക</string>
     <string name="start_radio">റേഡിയോ ആരംഭിക്കുക</string>
     <string name="play">പ്ലേ ചെയ്യുക</string>
     <string name="play_next">അടുത്തത് പ്ലേ ചെയ്യുക</string>
     <string name="add_to_queue">ക്യൂവിൽ ചേർക്കുക</string>
     <string name="add_to_library">ലൈബ്രറിയിലേക്ക് ചേർക്കുക</string>
-    <string name="remove_from_library">Remove from library</string>
     <string name="download">ഡൗൺലോഡ്</string>
-    <string name="downloading">Downloading</string>
     <string name="remove_download">ഡൗൺലോഡ് നീക്കം ചെയ്യുക</string>
     <string name="import_playlist">പ്ലേലിസ്റ്റ് ഇറക്കുമതി ചെയ്യുക</string>
     <string name="add_to_playlist">പ്ലേലിസ്റ്റിൽ ആഡ് ചെയ്യുക</string>
@@ -75,10 +49,6 @@
     <string name="refetch">വീണ്ടെടുക്കുക</string>
     <string name="share">പങ്കിടുക</string>
     <string name="delete">ഡിലീറ്റ്</string>
-    <string name="remove_from_history">Remove from history</string>
-    <string name="search_online">Search online</string>
-    <string name="sync">Sync</string>
-    <string name="advanced">Advanced</string>
     <!-- Sort menu -->
     <string name="sort_by_create_date">ചേർത്ത തീയതി</string>
     <string name="sort_by_name">പേര്</string>
@@ -86,21 +56,8 @@
     <string name="sort_by_year">വർഷം</string>
     <string name="sort_by_song_count">പാട്ടുകളുടെ എണ്ണം</string>
     <string name="sort_by_length">ദൈർഘ്യം</string>
-    <string name="sort_by_play_time">Play time</string>
-    <string name="sort_by_custom">Custom order</string>
     <!-- Dialog -->
-    <string name="media_id">Media id</string>
-    <string name="mime_type">MIME type</string>
-    <string name="codecs">Codecs</string>
-    <string name="bitrate">Bitrate</string>
-    <string name="sample_rate">Sample rate</string>
-    <string name="loudness">Loudness</string>
-    <string name="volume">Volume</string>
-    <string name="file_size">File size</string>
-    <string name="unknown">Unknown</string>
     <string name="copied">്ലിപ്പ്ബോർഡിലേക്ക് പകർത്തി</string>
-    <string name="edit_lyrics">Edit lyrics</string>
-    <string name="search_lyrics">Search lyrics</string>
     <string name="edit_song">ഗാനം എഡിറ്റ് ചെയ്യുക</string>
     <string name="song_title">പാട്ടിന്റെ പേര്</string>
     <string name="song_artists">പാട്ടുകാരൻ</string>
@@ -132,65 +89,24 @@
         <item quantity="one">%d പ്ലേലിസ്റ്റ്</item>
         <item quantity="other">%d പ്ലേലിസ്റ്റുകൾ</item>
     </plurals>
-    <plurals name="n_week" tools:ignore="MissingQuantity">
-        <item quantity="one">%d week</item>
-        <item quantity="other">%d weeks</item>
-    </plurals>
-    <plurals name="n_month" tools:ignore="MissingQuantity">
-        <item quantity="one">%d month</item>
-        <item quantity="other">%d months</item>
-    </plurals>
-    <plurals name="n_year" tools:ignore="MissingQuantity">
-        <item quantity="one">%d year</item>
-        <item quantity="other">%d years</item>
-    </plurals>
     <!-- Snackbar -->
     <string name="playlist_imported">പ്ലേലിസ്റ്റ് ഇറക്കുമതി ചെയ്തു</string>
-    <string name="removed_song_from_playlist">Removed \"%s\" from playlist</string>
-    <string name="playlist_synced">Playlist synced</string>
-    <string name="undo">Undo</string>
     <!-- Player -->
-    <string name="lyrics_not_found">Lyrics not found</string>
-    <string name="sleep_timer">Sleep timer</string>
-    <string name="end_of_song">End of song</string>
-    <plurals name="minute">
-        <item quantity="one">1 minute</item>
-        <item quantity="other">%d minutes</item>
-    </plurals>
-    <string name="error_no_stream">No stream available</string>
-    <string name="error_no_internet">No network connection</string>
-    <string name="error_timeout">Timeout</string>
-    <string name="error_unknown">Unknown error</string>
-    <!-- Player action -->
-    <string name="action_like">Like</string>
-    <string name="action_remove_like">Remove like</string>
-    <string name="action_shuffle_on">Shuffle on</string>
-    <string name="action_shuffle_off">Shuffle off</string>
-    <string name="repeat_mode_off">Repeat mode off</string>
-    <string name="repeat_mode_one">Repeat current song</string>
-    <string name="repeat_mode_all">Repeat queue</string>
-    <!-- Queue Title -->
-    <string name="queue_all_songs">All songs</string>
-    <string name="queue_searched_songs">Searched songs</string>
     <!-- Notification name -->
     <string name="music_player">മ്യൂസിക് പ്ലെയർ</string>
     <!-- Settings -->
     <string name="settings">ക്രമീകരണങ്ങൾ</string>
     <string name="appearance">രൂപഭംഗി</string>
-    <string name="enable_dynamic_theme">Enable dynamic theme</string>
     <string name="dark_theme">ഡാർക്ക് തീം</string>
     <string name="dark_theme_on">ഓൺ</string>
     <string name="dark_theme_off">ഓഫ്</string>
     <string name="dark_theme_follow_system">സിസ്റ്റം പിന്തുടരുക</string>
-    <string name="pure_black">Pure black</string>
     <string name="default_open_tab">സ്ഥിര ഓപ്പൺ ടാബ്</string>
-    <string name="customize_navigation_tabs">Customize navigation tabs</string>
     <string name="lyrics_text_position">വരികളുടെ സ്ഥാനം</string>
     <string name="left">ഇടത്</string>
     <string name="center">നടുക്ക്</string>
     <string name="right">വലത്</string>
     <string name="content">കന്റെന്റ്</string>
-    <string name="login">Login</string>
     <string name="content_language">സ്ഥിര കന്റെന്റ് ഭാഷ</string>
     <string name="content_country">സ്ഥിര കന്റെന്റ് രാജ്യം</string>
     <string name="system_default">സിസ്റ്റം സ്ഥിരസ്ഥിതി</string>
@@ -204,41 +120,21 @@
     <string name="audio_quality_high">കൂടി</string>
     <string name="audio_quality_low">കുറഞ്ഞ്</string>
     <string name="persistent_queue">പെർസിസ്റ്റന്റ് കീ</string>
-    <string name="skip_silence">Skip silence</string>
-    <string name="audio_normalization">Audio normalization</string>
     <string name="equalizer">ഇക്വലൈസർ</string>
-    <string name="storage">Storage</string>
-    <string name="cache">Cache</string>
-    <string name="image_cache">Image Cache</string>
-    <string name="song_cache">Song Cache</string>
-    <string name="max_cache_size">Max cache size</string>
     <string name="unlimited">പരിധിയില്ലാത്ത</string>
     <string name="clear_all_downloads">"ഡൗൺലോഡുകൾ  എല്ലാം നീക്കം ചെയ്യുക"</string>
-    <string name="max_image_cache_size">Max image cache size</string>
-    <string name="clear_image_cache">Clear image cache</string>
-    <string name="max_song_cache_size">Max song cache size</string>
-    <string name="clear_song_cache">Clear song cache</string>
-    <string name="size_used">%s used</string>
     <string name="privacy">സ്വകാര്യത</string>
-    <string name="pause_listen_history">Pause listen history</string>
-    <string name="clear_listen_history">Clear listen history</string>
-    <string name="clear_listen_history_confirm">Are you sure to clear all listen history?</string>
     <string name="pause_search_history">തിരയൽ ചരിത്രം താൽക്കാലികമായി നിർത്തുക</string>
     <string name="clear_search_history">തിരയൽ ചരിത്രം മായ്‌ക്കുക</string>
     <string name="clear_search_history_confirm">എല്ലാ തിരയൽ ചരിത്രവും മായ്‌ക്കണമെന്ന് ഉറപ്പാണോ?</string>
-    <string name="enable_kugou">Enable KuGou lyrics provider</string>
     <string name="backup_restore">ബാക്കപ്പും വീണ്ടെടുക്കലും</string>
     <string name="backup">ബാക്കപ്പ്</string>
     <string name="restore">വീണ്ടെടുക്കൽ</string>
-    <string name="imported_playlist">Imported playlist</string>
     <string name="backup_create_success">ബാക്കപ്പ് സൃഷ്‌ടിച്ചു</string>
     <string name="backup_create_failed">ബാക്കപ്പ് സൃഷ്ടിക്കാൻ കഴിഞ്ഞില്ല</string>
     <string name="restore_failed">ബാക്കപ്പ് പുനഃസ്ഥാപിക്കാൻ കഴിഞ്ഞില്ല</string>
     <string name="about">കുറിച്ച്</string>
     <string name="app_version">അപ്ലിക്കേഷൻ പതിപ്പ്</string>
-    <string name="new_version_available">New version available</string>
-    <string name="translation_models">Translation Models</string>
-    <string name="clear_translation_models">Clear translation models</string>
     <string name="use_login_for_browse_desc">ഇത് നിങ്ങൾ കാണുന്ന ഉള്ളടക്കത്തെ സ്വാധീനിക്കും, ഉദാഹരണത്തിന് നിങ്ങൾ ഒരു പ്രീമിയം അക്കൗണ്ട് ഉപയോഗിച്ച് ലോഗിൻ ചെയ്തിട്ടുണ്ടെങ്കിൽ പ്രീമിയം-മാത്രം ആൽബങ്ങൾ കാണിക്കുന്നു</string>
     <string name="forgotten_favorites">മറന്ന മധുരങ്ങള്‍</string>
     <string name="keep_listening">കേള്‍ക്കുന്നത് തുടരൂ</string>

--- a/app/src/main/res/values-or-rIN/strings.xml
+++ b/app/src/main/res/values-or-rIN/strings.xml
@@ -6,39 +6,10 @@
     <string name="albums">ଆଲବମ୍</string>
     <string name="playlists">ପ୍ଲେଲିଷ୍ଟଗୁଡିକ</string>
 
-    <!-- Top bar -->
-    <plurals name="n_selected">
-        <item quantity="one">%d selected</item>
-        <item quantity="other">%d selected</item>
-    </plurals>
-
-    <!-- Home -->
-    <string name="history">History</string>
-    <string name="stats">Stats</string>
-    <string name="mood_and_genres">Mood and Genres</string>
-    <string name="account">Account</string>
-    <string name="quick_picks">Quick picks</string>
-    <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">New release albums</string>
-
-    <!-- History -->
-    <string name="today">Today</string>
-    <string name="yesterday">Yesterday</string>
-    <string name="this_week">This week</string>
-    <string name="last_week">Last week</string>
-
-    <!-- Stats -->
-    <string name="most_played_songs">Most played songs</string>
-    <string name="most_played_artists">Most played artists</string>
-    <string name="most_played_albums">Most played albums</string>
-
     <!-- Search -->
     <string name="search">ସନ୍ଧାନ କରନ୍ତୁ</string>
     <string name="search_yt_music">ୟୁଟ୍ୟୁବ୍ ମ୍ୟୁଜିକ୍ ଖୋଜ…</string>
     <string name="search_library">ଲାଇବ୍ରେରୀ ଖୋଜ…</string>
-    <string name="filter_library">Library</string>
-    <string name="filter_liked">Liked</string>
-    <string name="filter_downloaded">Downloaded</string>
     <string name="filter_all">ସମସ୍ତ</string>
     <string name="filter_songs">ସଙ୍ଗୀତ ଗୁଡ଼ିକ</string>
     <string name="filter_videos">ଭିଡିଓ ଗୁଡ଼ିକ</string>
@@ -47,8 +18,6 @@
     <string name="filter_playlists">ପ୍ଲେଲିଷ୍ଟ ଗୁଡ଼ିକ</string>
     <string name="filter_community_playlists">ସମ୍ପ୍ରଦାୟ ପ୍ଲେଲିଷ୍ଟଗୁଡିକ</string>
     <string name="filter_featured_playlists">ବୈଶିଷ୍ଟ୍ୟଯୁକ୍ତ ତାଲିକାଗୁଡ଼ିକ</string>
-    <string name="filter_bookmarked">Bookmarked</string>
-    <string name="no_results_found">No results found</string>
 
     <!-- Artist screen -->
     <string name="from_your_library">ଆପଣଙ୍କ ଲାଇବ୍ରେରୀରୁ</string>
@@ -56,7 +25,6 @@
     <!-- Playlist -->
     <string name="liked_songs">ପସନ୍ଦିତ ଗୀତ ଗୁଡ଼ିକ</string>
     <string name="downloaded_songs">ସଞ୍ଚିତ ଗୀତ ଗୁଡ଼ିକ</string>
-    <string name="playlist_is_empty">The playlist is empty</string>
 
     <!-- Button -->
     <string name="retry">ପୁନଃ ଚେଷ୍ଟା କରନ୍ତୁ</string>
@@ -83,10 +51,7 @@
     <string name="refetch">ପୁନଃ ଆଣନ୍ତୁ</string>
     <string name="share">ଅଂଶୀଦାର କରନ୍ତୁ</string>
     <string name="delete">ବିଲୋପ କରନ୍ତୁ</string>
-    <string name="remove_from_history">Remove from history</string>
     <string name="search_online">ଅନଲାଇନ୍ ସନ୍ଧାନ କରନ୍ତୁ</string>
-    <string name="sync">Sync</string>
-    <string name="advanced">Advanced</string>
 
     <!-- Sort menu -->
     <string name="sort_by_create_date">ତାରିଖ ରେ ଯୋଡା ଯାଇଛି</string>
@@ -96,7 +61,6 @@
     <string name="sort_by_song_count">ସଙ୍ଗୀତ ସଂଖ୍ୟା</string>
     <string name="sort_by_length">ସମୟ</string>
     <string name="sort_by_play_time">ଚାଲିଥିବା ସମୟ</string>
-    <string name="sort_by_custom">Custom order</string>
 
     <!-- Dialog -->
     <string name="media_id">ମିଡିଆ id</string>
@@ -130,50 +94,11 @@
     <string name="artist_name">କଳାକାର ନାମ</string>
     <string name="error_artist_name_empty">କଳାକାରଙ୍କ ନାମ ଖାଲି ହୋଇପାରିବ ନାହିଁ ।</string>
 
-    <!-- Noun -->
-    <plurals name="n_song">
-        <item quantity="one">%d song</item>
-        <item quantity="other">%d songs</item>
-    </plurals>
-    <plurals name="n_artist">
-        <item quantity="one">%d artist</item>
-        <item quantity="other">%d artists</item>
-    </plurals>
-    <plurals name="n_album">
-        <item quantity="one">%d album</item>
-        <item quantity="other">%d albums</item>
-    </plurals>
-    <plurals name="n_playlist">
-        <item quantity="one">%d playlist</item>
-        <item quantity="other">%d playlists</item>
-    </plurals>
-    <plurals name="n_week" tools:ignore="MissingQuantity">
-        <item quantity="one">%d week</item>
-        <item quantity="other">%d weeks</item>
-    </plurals>
-    <plurals name="n_month" tools:ignore="MissingQuantity">
-        <item quantity="one">%d month</item>
-        <item quantity="other">%d months</item>
-    </plurals>
-    <plurals name="n_year" tools:ignore="MissingQuantity">
-        <item quantity="one">%d year</item>
-        <item quantity="other">%d years</item>
-    </plurals>
-
     <!-- Snackbar -->
     <string name="playlist_imported">ପ୍ଲେଲିଷ୍ଟ ଆମଦାନୀ ହୋଇଛି</string>
-    <string name="removed_song_from_playlist">Removed \"%s\" from playlist</string>
-    <string name="playlist_synced">Playlist synced</string>
-    <string name="undo">Undo</string>
 
     <!-- Player -->
     <string name="lyrics_not_found">ଗୀତ ର ପାଠ୍ୟ ମିଳିଲା ନାହିଁ</string>
-    <string name="sleep_timer">Sleep timer</string>
-    <string name="end_of_song">End of song</string>
-    <plurals name="minute">
-        <item quantity="one">1 minute</item>
-        <item quantity="other">%d minutes</item>
-    </plurals>
     <string name="error_no_stream">କୌଣସି ଷ୍ଟ୍ରିମ୍ ଉପଲବ୍ଧ ନାହିଁ</string>
     <string name="error_no_internet">କୌଣସି ନେଟୱର୍କ ସଂଯୋଗ ନାହିଁ</string>
     <string name="error_timeout">ସମୟ ଶେଷ</string>
@@ -182,12 +107,6 @@
     <!-- Player action -->
     <string name="action_like">ପସନ୍ଦ କରନ୍ତୁ</string>
     <string name="action_remove_like">ପଶନ୍ଦ ଅପସାରଣ କରନ୍ତୁ</string>
-    <string name="action_shuffle_on">Shuffle on</string>
-    <string name="action_shuffle_off">Shuffle off</string>
-    <string name="repeat_mode_off">Repeat mode off</string>
-    <string name="repeat_mode_one">Repeat current song</string>
-    <string name="repeat_mode_all">Repeat queue</string>
-
     <!-- Queue Title -->
     <string name="queue_all_songs">ସମସ୍ତ ଗୀତ</string>
     <string name="queue_searched_songs">ଖୋଜାଜାଇଥିବା ଗୀତ ଗୁଡ଼ିକ</string>
@@ -198,12 +117,10 @@
     <!-- Settings -->
     <string name="settings">ସେଟିଂ ସମୂହ</string>
     <string name="appearance">ଦୃଶ୍ୟତା</string>
-    <string name="enable_dynamic_theme">Enable dynamic theme</string>
     <string name="dark_theme">ଗାଢ଼ ଥିମ୍</string>
     <string name="dark_theme_on">ଅନ୍</string>
     <string name="dark_theme_off">ଅଫ୍</string>
     <string name="dark_theme_follow_system">ସିଷ୍ଟମ୍ ଅନୁସରଣ କରନ୍ତୁ</string>
-    <string name="pure_black">Pure black</string>
     <string name="default_open_tab">ଡିଫଲ୍ଟ ଖୋଲା ଟ୍ୟାବ୍</string>
     <string name="customize_navigation_tabs">ନାଭିଗେସନ୍ ଟ୍ୟାବ୍ କଷ୍ଟୋମାଇଜ୍ କରନ୍ତୁ</string>
     <string name="lyrics_text_position">ଗୀତ ପାଠ୍ୟ ଅବସ୍ଥାନ</string>
@@ -233,21 +150,12 @@
 
     <string name="storage">ଭଣ୍ଡାର</string>
     <string name="cache">କ୍ୟାଚ୍</string>
-    <string name="image_cache">Image Cache</string>
-    <string name="song_cache">Song Cache</string>
-    <string name="max_cache_size">Max cache size</string>
-    <string name="unlimited">Unlimited</string>
-    <string name="clear_all_downloads">Clear all downloads</string>
     <string name="max_image_cache_size">ସର୍ବାଧିକ ପ୍ରତିଛବି କ୍ୟାଚ୍ ଆକାର</string>
     <string name="clear_image_cache">ପ୍ରତିଛବି କ୍ୟାଚ୍ ସଫା କରନ୍ତୁ</string>
     <string name="max_song_cache_size">ସର୍ବାଧିକ ଗୀତ କ୍ୟାଚ୍ ଆକାର</string>
-    <string name="clear_song_cache">Clear song cache</string>
     <string name="size_used">%s ବ୍ୟବହୃତ</string>
 
     <string name="privacy">ଗୋପନୀୟତା</string>
-    <string name="pause_listen_history">Pause listen history</string>
-    <string name="clear_listen_history">Clear listen history</string>
-    <string name="clear_listen_history_confirm">Are you sure to clear all listen history?</string>
     <string name="pause_search_history">ସନ୍ଧାନ ଇତିହାସକୁ ବିରତି ଦିଅ</string>
     <string name="clear_search_history">ସନ୍ଧାନ ଇତିହାସ ସଫା କରନ୍ତୁ</string>
     <string name="clear_search_history_confirm">ଆପଣ ସମସ୍ତ ସନ୍ଧାନ ଇତିହାସ ସଫା କରିବାକୁ ନିଶ୍ଚିତ କି?</string>
@@ -256,15 +164,10 @@
     <string name="backup_restore">ନକଲ ସଂରକ୍ଷଣ ଏବଂ ପୁନରୁଦ୍ଧାର କରନ୍ତୁ</string>
     <string name="backup">ନକଲ ସଂରକ୍ଷଣ</string>
     <string name="restore">ପୁନରୁଦ୍ଧାର କରନ୍ତୁ</string>
-    <string name="imported_playlist">Imported playlist</string>
     <string name="backup_create_success">ବ୍ୟାକଅପ୍ ସଫଳତାର ସହିତ ସୃଷ୍ଟି ହେଲା</string>
     <string name="backup_create_failed">ବ୍ୟାକଅପ୍ ସୃଷ୍ଟି କରିପାରିବ ନାହିଁ</string>
     <string name="restore_failed">ବ୍ୟାକଅପ୍ ପୁନରୁଦ୍ଧାର କରିବାରେ ବିଫଳ</string>
 
     <string name="about">ବିଷୟରେ</string>
     <string name="app_version">ଆପ୍ ସଂସ୍କରଣ</string>
-
-    <string name="new_version_available">New version available</string>
-    <string name="translation_models">Translation Models</string>
-    <string name="clear_translation_models">Clear translation models</string>
 </resources>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -1,9 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Bottom navigation -->
-    <string name="home">Home</string>
     <string name="songs">Låtar</string>
     <string name="artists">Artister</string>
-    <string name="albums">Albums</string>
     <string name="playlists">Spellistor</string>
 
     <!-- Top bar -->
@@ -12,106 +10,32 @@
         <item quantity="other">%d valda</item>
     </plurals>
 
-    <!-- Home -->
-    <string name="history">History</string>
-    <string name="stats">Stats</string>
-    <string name="mood_and_genres">Mood and Genres</string>
-    <string name="account">Account</string>
-    <string name="quick_picks">Quick picks</string>
-    <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">New release albums</string>
-
-    <!-- History -->
-    <string name="today">Today</string>
-    <string name="yesterday">Yesterday</string>
-    <string name="this_week">This week</string>
-    <string name="last_week">Last week</string>
-
-    <!-- Stats -->
-    <string name="most_played_songs">Most played songs</string>
-    <string name="most_played_artists">Most played artists</string>
-    <string name="most_played_albums">Most played albums</string>
-
     <!-- Search -->
     <string name="search">Sök</string>
-    <string name="search_yt_music">Search YouTube Music…</string>
-    <string name="search_library">Search library…</string>
-    <string name="filter_library">Library</string>
-    <string name="filter_liked">Liked</string>
-    <string name="filter_downloaded">Downloaded</string>
     <string name="filter_all">Alla</string>
     <string name="filter_songs">Låtar</string>
     <string name="filter_videos">Videor</string>
     <string name="filter_albums">Album</string>
     <string name="filter_artists">Artister</string>
     <string name="filter_playlists">Spellistor</string>
-    <string name="filter_community_playlists">Community playlists</string>
-    <string name="filter_featured_playlists">Featured playlists</string>
-    <string name="filter_bookmarked">Bookmarked</string>
-    <string name="no_results_found">No results found</string>
 
-    <!-- Artist screen -->
-    <string name="from_your_library">From your library</string>
-
-    <!-- Playlist -->
-    <string name="liked_songs">Liked songs</string>
-    <string name="downloaded_songs">Downloaded songs</string>
-    <string name="playlist_is_empty">The playlist is empty</string>
 
     <!-- Button -->
     <string name="retry">Försök igen</string>
-    <string name="radio">Radio</string>
     <string name="shuffle">Blanda</string>
-    <string name="reset">Reset</string>
 
     <!-- Menu -->
-    <string name="details">Details</string>
     <string name="edit">Redigera</string>
-    <string name="start_radio">Start radio</string>
-    <string name="play">Play</string>
     <string name="play_next">Spela upp nästa</string>
     <string name="add_to_queue">Lägg till i kön</string>
-    <string name="add_to_library">Add to library</string>
-    <string name="remove_from_library">Remove from library</string>
     <string name="download">Ladda ned</string>
-    <string name="downloading">Downloading</string>
     <string name="remove_download">Ta bort nedladdning</string>
     <string name="import_playlist">Import playlist</string>
     <string name="add_to_playlist">Lägg till i spellista</string>
-    <string name="view_artist">View artist</string>
-    <string name="view_album">View album</string>
-    <string name="refetch">Refetch</string>
-    <string name="share">Share</string>
     <string name="delete">Ta bort</string>
-    <string name="remove_from_history">Remove from history</string>
-    <string name="search_online">Search online</string>
-    <string name="sync">Sync</string>
-    <string name="advanced">Advanced</string>
-
     <!-- Sort menu -->
     <string name="sort_by_create_date">Datum tillagd</string>
     <string name="sort_by_name">Namn</string>
-    <string name="sort_by_artist">Artist</string>
-    <string name="sort_by_year">Year</string>
-    <string name="sort_by_song_count">Song count</string>
-    <string name="sort_by_length">Length</string>
-    <string name="sort_by_play_time">Play time</string>
-    <string name="sort_by_custom">Custom order</string>
-
-    <!-- Dialog -->
-    <string name="media_id">Media id</string>
-    <string name="mime_type">MIME type</string>
-    <string name="codecs">Codecs</string>
-    <string name="bitrate">Bitrate</string>
-    <string name="sample_rate">Sample rate</string>
-    <string name="loudness">Loudness</string>
-    <string name="volume">Volume</string>
-    <string name="file_size">File size</string>
-    <string name="unknown">Unknown</string>
-    <string name="copied">Copied to clipboard</string>
-
-    <string name="edit_lyrics">Edit lyrics</string>
-    <string name="search_lyrics">Search lyrics</string>
 
     <string name="edit_song">Redigera låten</string>
     <string name="song_title">Låt titel</string>
@@ -135,62 +59,6 @@
         <item quantity="one">%d låt</item>
         <item quantity="other">%d låtar</item>
     </plurals>
-    <plurals name="n_artist">
-        <item quantity="one">%d artist</item>
-        <item quantity="other">%d artists</item>
-    </plurals>
-    <plurals name="n_album">
-        <item quantity="one">%d album</item>
-        <item quantity="other">%d albums</item>
-    </plurals>
-    <plurals name="n_playlist">
-        <item quantity="one">%d playlist</item>
-        <item quantity="other">%d playlists</item>
-    </plurals>
-    <plurals name="n_week" tools:ignore="MissingQuantity">
-        <item quantity="one">%d week</item>
-        <item quantity="other">%d weeks</item>
-    </plurals>
-    <plurals name="n_month" tools:ignore="MissingQuantity">
-        <item quantity="one">%d month</item>
-        <item quantity="other">%d months</item>
-    </plurals>
-    <plurals name="n_year" tools:ignore="MissingQuantity">
-        <item quantity="one">%d year</item>
-        <item quantity="other">%d years</item>
-    </plurals>
-
-    <!-- Snackbar -->
-    <string name="playlist_imported">Playlist imported</string>
-    <string name="removed_song_from_playlist">Removed \"%s\" from playlist</string>
-    <string name="playlist_synced">Playlist synced</string>
-    <string name="undo">Undo</string>
-
-    <!-- Player -->
-    <string name="lyrics_not_found">Lyrics not found</string>
-    <string name="sleep_timer">Sleep timer</string>
-    <string name="end_of_song">End of song</string>
-    <plurals name="minute">
-        <item quantity="one">1 minute</item>
-        <item quantity="other">%d minutes</item>
-    </plurals>
-    <string name="error_no_stream">No stream available</string>
-    <string name="error_no_internet">No network connection</string>
-    <string name="error_timeout">Timeout</string>
-    <string name="error_unknown">Unknown error</string>
-
-    <!-- Player action -->
-    <string name="action_like">Like</string>
-    <string name="action_remove_like">Remove like</string>
-    <string name="action_shuffle_on">Shuffle on</string>
-    <string name="action_shuffle_off">Shuffle off</string>
-    <string name="repeat_mode_off">Repeat mode off</string>
-    <string name="repeat_mode_one">Repeat current song</string>
-    <string name="repeat_mode_all">Repeat queue</string>
-
-    <!-- Queue Title -->
-    <string name="queue_all_songs">All songs</string>
-    <string name="queue_searched_songs">Searched songs</string>
 
     <!-- Notification name -->
     <string name="music_player">Music Spelare</string>
@@ -198,73 +66,15 @@
     <!-- Settings -->
     <string name="settings">Inställningar</string>
     <string name="appearance">Utseende</string>
-    <string name="enable_dynamic_theme">Enable dynamic theme</string>
     <string name="dark_theme">Mörkt tema</string>
     <string name="dark_theme_on">På</string>
     <string name="dark_theme_off">Av</string>
     <string name="dark_theme_follow_system">Följ systemet</string>
-    <string name="pure_black">Pure black</string>
-    <string name="default_open_tab">Default open tab</string>
-    <string name="customize_navigation_tabs">Customize navigation tabs</string>
-    <string name="lyrics_text_position">Lyrics text position</string>
-    <string name="left">Left</string>
-    <string name="center">Center</string>
-    <string name="right">Right</string>
 
     <string name="content">Innehåll</string>
-    <string name="login">Login</string>
     <string name="content_language">Standard innehållsspråk</string>
     <string name="content_country">Standard innehållsland</string>
     <string name="system_default">Systemets standardinställning</string>
-    <string name="enable_proxy">Enable proxy</string>
-    <string name="proxy_type">Proxy type</string>
-    <string name="proxy_url">Proxy URL</string>
-    <string name="restart_to_take_effect">Restart to take effect</string>
-
-    <string name="player_and_audio">Player and audio</string>
-    <string name="audio_quality">Audio quality</string>
-    <string name="audio_quality_auto">Auto</string>
-    <string name="audio_quality_high">High</string>
-    <string name="audio_quality_low">Low</string>
-    <string name="persistent_queue">Persistent queue</string>
-    <string name="skip_silence">Skip silence</string>
-    <string name="audio_normalization">Audio normalization</string>
-    <string name="equalizer">Equalizer</string>
-
-    <string name="storage">Storage</string>
-    <string name="cache">Cache</string>
-    <string name="image_cache">Image Cache</string>
-    <string name="song_cache">Song Cache</string>
-    <string name="max_cache_size">Max cache size</string>
-    <string name="unlimited">Unlimited</string>
-    <string name="clear_all_downloads">Clear all downloads</string>
-    <string name="max_image_cache_size">Max image cache size</string>
-    <string name="clear_image_cache">Clear image cache</string>
-    <string name="max_song_cache_size">Max song cache size</string>
-    <string name="clear_song_cache">Clear song cache</string>
-    <string name="size_used">%s used</string>
-
-    <string name="privacy">Privacy</string>
-    <string name="pause_listen_history">Pause listen history</string>
-    <string name="clear_listen_history">Clear listen history</string>
-    <string name="clear_listen_history_confirm">Are you sure to clear all listen history?</string>
-    <string name="pause_search_history">Pause search history</string>
-    <string name="clear_search_history">Clear search history</string>
-    <string name="clear_search_history_confirm">Are you sure to clear all search history?</string>
-    <string name="enable_kugou">Enable KuGou lyrics provider</string>
-
-    <string name="backup_restore">Backup and restore</string>
-    <string name="backup">Backup</string>
-    <string name="restore">Restore</string>
-    <string name="imported_playlist">Imported playlist</string>
-    <string name="backup_create_success">Backup created successfully</string>
-    <string name="backup_create_failed">Couldn\'t create backup</string>
-    <string name="restore_failed">Failed to restore backup</string>
 
     <string name="about">Om</string>
-    <string name="app_version">App version</string>
-
-    <string name="new_version_available">New version available</string>
-    <string name="translation_models">Translation Models</string>
-    <string name="clear_translation_models">Clear translation models</string>
 </resources>


### PR DESCRIPTION
these translations didn't address these, these only exist because of the `MissingTranslation` lint check which is now disabled

weblate complains about these as strings with multiple failing checks, because in many languages the same strings have untranslated, duplicated english strings
