### PR TITLE
Fixes for Discord RPC

### DIFF
--- a/kizzy/src/main/java/com/my/kizzy/remote/ApiService.kt
+++ b/kizzy/src/main/java/com/my/kizzy/remote/ApiService.kt
@@ -45,21 +45,25 @@ class ApiService {
         }
     }
 
-    suspend fun getImage(url: String) = client.get {
-        url("$BASE_URL/image")
-        parameter("url", url)
+    suspend fun getImage(url: String) = runCatching {
+        client.get {
+            url("$BASE_URL/image")
+            parameter("url", url)
+        }
     }
 
-    suspend fun uploadImage(file: File) = client.post {
-        url("$BASE_URL/upload")
-        setBody(MultiPartFormDataContent(
-            formData {
-                append("\"temp\"", file.readBytes(), Headers.build {
-                    append(HttpHeaders.ContentType, "image/*")
-                    append(HttpHeaders.ContentDisposition, "filename=\"${file.name}\"")
-                })
-            }
-        ))
+    suspend fun uploadImage(file: File) = runCatching {
+        client.post {
+            url("$BASE_URL/upload")
+            setBody(MultiPartFormDataContent(
+                formData {
+                    append("\"temp\"", file.readBytes(), Headers.build {
+                        append(HttpHeaders.ContentType, "image/*")
+                        append(HttpHeaders.ContentDisposition, "filename=\"${file.name}\"")
+                    })
+                }
+            ))
+        }
     }
 
     companion object {

--- a/kizzy/src/main/java/com/my/kizzy/remote/ApiService.kt
+++ b/kizzy/src/main/java/com/my/kizzy/remote/ApiService.kt
@@ -54,9 +54,9 @@ class ApiService {
         url("$BASE_URL/upload")
         setBody(MultiPartFormDataContent(
             formData {
-                append("temp", file.readBytes(), Headers.build {
+                append("\"temp\"", file.readBytes(), Headers.build {
                     append(HttpHeaders.ContentType, "image/*")
-                    append(HttpHeaders.ContentDisposition, "filename=${file.name}")
+                    append(HttpHeaders.ContentDisposition, "filename=\"${file.name}\"")
                 })
             }
         ))

--- a/kizzy/src/main/java/com/my/kizzy/repository/KizzyRepository.kt
+++ b/kizzy/src/main/java/com/my/kizzy/repository/KizzyRepository.kt
@@ -23,10 +23,10 @@ class KizzyRepository {
     private val api = ApiService()
 
     suspend fun getImage(url: String): String? {
-        return api.getImage(url).toImageAsset()
+        return api.getImage(url).getOrNull()?.toImageAsset()
     }
 
     suspend fun uploadImage(file: File): String? {
-        return api.uploadImage(file).toImageAsset()
+        return api.uploadImage(file).getOrNull()?.toImageAsset()
     }
 }


### PR DESCRIPTION
These are cherry-picks of some recent fixes from the original Kizzy repo after it had been implemented here, which fixes Discord RPC not working.

Although now working, several original issues still persist.

Fixes #1725.