### PR TITLE
Fix search for some specific queries

### DIFF
--- a/app/src/main/java/com/zionhuang/music/MainActivity.kt
+++ b/app/src/main/java/com/zionhuang/music/MainActivity.kt
@@ -153,7 +153,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.net.URLDecoder
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.days
 
@@ -389,7 +388,7 @@ class MainActivity : ComponentActivity() {
                     LaunchedEffect(navBackStackEntry) {
                         if (navBackStackEntry?.destination?.route?.startsWith("search/") == true) {
                             val searchQuery = withContext(Dispatchers.IO) {
-                                URLDecoder.decode(navBackStackEntry?.arguments?.getString("query")!!, "UTF-8")
+                                navBackStackEntry?.arguments?.getString("query")!!
                             }
                             onQueryChange(TextFieldValue(searchQuery, TextRange(searchQuery.length)))
                         } else if (navigationItems.fastAny { it.route == navBackStackEntry?.destination?.route }) {

--- a/app/src/main/java/com/zionhuang/music/utils/StringUtils.kt
+++ b/app/src/main/java/com/zionhuang/music/utils/StringUtils.kt
@@ -1,7 +1,7 @@
 package com.zionhuang.music.utils
 
+import android.net.Uri
 import java.math.BigInteger
-import java.net.URLEncoder
 import java.security.MessageDigest
 
 fun makeTimeString(duration: Long?): String {
@@ -30,4 +30,4 @@ fun joinByBullet(vararg str: String?) =
         it.isNullOrEmpty()
     }.joinToString(separator = " • ")
 
-fun String.urlEncode(): String = URLEncoder.encode(this, "UTF-8")
+fun String.urlEncode(): String = Uri.encode(this)


### PR DESCRIPTION
Compose appears to already be doing this for us, which will cause issues when strings contain '%' signs due to its usage in x-www-form-urlencoded. Fix by removing the final decode checks.

Original report by @josprox, with reference fix provided [1], however the patch includes unnecessary String sanitization which can cause further issues down the line.

[1]: https://github.com/josprox/Joss-Music/commit/ad58ab4930aacb2256436ea4fc1c45172caa80b4

---

Compose still pose as a huge hassle with handling whitespace for encoded URLs. While URLEncoder work with specific characters, it performs poor handling with other characters.

Android's built-in Uri class appears to work well for all Unicode characters, since it encodes characters into "'%'-escaped octets", so use that instead.