### PR TITLE
Automatic per-app language preferences

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,6 +99,10 @@ android {
     lint {
         lintConfig = file("app/lint.xml")
     }
+    androidResources {
+        // Gives users the option to change the app language in the app info page
+        generateLocaleConfig = true
+    }
 }
 
 ksp {

--- a/app/src/main/res/resources.properties
+++ b/app/src/main/res/resources.properties
@@ -1,0 +1,1 @@
+unqualifiedResLocale=en-US


### PR DESCRIPTION
https://developer.android.com/guide/topics/resources/app-languages

Allows users with Android 13+ devices to change the language of the app individually

Closes #1776 #1380 